### PR TITLE
@dblock Add test for logout if calling logout deletes req.user

### DIFF
--- a/test/index.coffee
+++ b/test/index.coffee
@@ -207,6 +207,7 @@ describe 'Artsy Passport methods', ->
       @logoutSpy.called.should.be.true
       @del.args[0][0].should.containEql '/api/v1/access_token'
       @send.args[0][0].should.eql access_token: 'secret'
+      (@req.user?).should.not.be.ok
       @next.called.should.be.true
 
     it 'still works if there is no access token', ->


### PR DESCRIPTION
We had a test for https://github.com/artsy/artsy-passport/pull/30 it just stubbed `req.logout` incorrectly 
