### PR TITLE
@dzucconi Handle case when the server errors when deleting access token

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -278,12 +278,12 @@ accessTokenCallback = (done, params) ->
       console.warn "Error requesting an access token from Artsy: " + res?.text
       done err
 
-destroyAccessToken = (req, res, next, accessToken) ->
+destroyAccessToken = (next, accessToken) ->
   if accessToken
     request
       .del("#{opts.SECURE_ARTSY_URL}/api/v1/access_token")
       .send(access_token: accessToken)
-      .end (res) ->
+      .end (error, response) ->
         next()
   else
     next()
@@ -291,7 +291,7 @@ destroyAccessToken = (req, res, next, accessToken) ->
 logout = (req, res, next) ->
   accessToken = req.user?.get('accessToken')
   req.logout()
-  destroyAccessToken(req, res, next, accessToken)
+  destroyAccessToken(next, accessToken)
 
 #
 # Serialize user by fetching and caching user data in the session.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "artsy-passport",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "description": "Wires up the common auth handlers for Artsy's [Ezel](ezeljs.com)-based apps using [passport](http://passportjs.org/).",
     "keywords": [
         "artsy",

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -195,19 +195,26 @@ describe 'Artsy Passport methods', ->
 
   describe '#logout', ->
     beforeEach ->
-      @artsyPassport.__set__ 'request', del: @del = sinon.stub().returns(send: @send = sinon.stub().returns(end: (cb) -> cb()))
+      @send = sinon.stub().returns(end: (cb) -> cb())
+      @del = sinon.stub().returns(send: @send)
       @logout = @artsyPassport.__get__ 'logout'
-      @req = { query: {}, get: (-> 'access-foo-token'), logout: (=> @req.user = null), user: {get: -> 'secret'} }
+      @req = { query: {}, get: (-> 'access-foo-token'), logout: (=> @req.user = null), user: { get: -> 'secret' } }
       @res = { send: sinon.stub() }
       @logoutSpy = sinon.spy(@req, 'logout');
       @next = sinon.stub()
 
     it 'logs out, deletes the auth token, and redirects home', ->
+      @artsyPassport.__set__ 'request', del: @del
       @logout @req, @res, @next
       @logoutSpy.called.should.be.true
       @del.args[0][0].should.containEql '/api/v1/access_token'
       @send.args[0][0].should.eql access_token: 'secret'
       (@req.user?).should.not.be.ok
+      @next.called.should.be.true
+
+    it 'logs out, deletes the auth token, and redirects home', ->
+      @artsyPassport.__set__ 'request', del: -> send: -> end: (cb) -> cb({ error: true }, { code: 500, error: 'Fake error', ok: false })
+      @logout @req, @res, @next
       @next.called.should.be.true
 
     it 'still works if there is no access token', ->


### PR DESCRIPTION
Currently, if you log out and your access token is already deleted you will get a 500 page - this fixes the issue by handling errors in superagent.
