### PR TITLE
@broskoski => Sign-out via DELETE only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ app.use artsyPassport
   CurrentUser: # Backbone Model class to serialize the user into e.g. `CurrentUser`
   # Temporary generated email for twitter signup.
   twitterSignupTempEmail: (token, secret, profile) -> 'md5hash@artsy.tmp'
-  # Path for a "One last step" UI that lets Artsy store the user's email after 
+  # Path for a "One last step" UI that lets Artsy store the user's email after
   # twitter signup.
   twitterLastStepPath: '/users/auth/twitter/email'
 ````
@@ -156,4 +156,4 @@ module.exports =
   FACEBOOK_PASSWORD: '***'
 ````
 
-Then you can check the example by running `make example` and opening [localhost:4000](http://localhost:4000). The tests are integration tests that use the example, so once you set this up run `make test` to run tests.
+Then you can check the example by running `make example` and opening [localhost:4000](http://localhost:3000). The tests are integration tests that use the example, so once you set this up run `make test` to run tests.

--- a/example/client.coffee
+++ b/example/client.coffee
@@ -2,3 +2,12 @@ sd = require('sharify').data
 
 $ ->
   $('body').append "<br><br>your email from the client-side!<br> " + sd.CURRENT_USER.email
+
+  $('a.logout').click ->
+    $.ajax
+      url: '/users/sign_out'
+      type: 'DELETE'
+      success: ->
+        window.location = '/'
+      error: (xhr, status, error) ->
+        alert(error)

--- a/example/index.coffee
+++ b/example/index.coffee
@@ -70,8 +70,8 @@ setup = (app) ->
   app.get '/personalize', (req, res) ->
     res.redirect '/' unless req.user?
     res.send 'Personalize Flow for ' + req.user.get('name')
-  app.get '/users/sign_out', (req, res) ->
-    res.redirect '/'
+  app.delete '/users/sign_out', (req, res) ->
+    res.send JSON.stringify(status: 'ok')
 
   return unless module is require.main
   app.listen 3000, -> console.log "Example listening on 3000"

--- a/example/loggedin.jade
+++ b/example/loggedin.jade
@@ -4,7 +4,7 @@ html(lang="en")
     title Login
   body
     h1 Hello #{user.get('name')}
-    a( href='/users/sign_out' ) Logout
+    a.logout( href='#' ) Logout
     != sharify.script()
     script( src='//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js' )
     script( src='/client.js' )

--- a/example/public/client.js
+++ b/example/public/client.js
@@ -4,7 +4,19 @@ var sd;
 sd = require('sharify').data;
 
 $(function() {
-  return $('body').append("<br><br>your email from the client-side!<br> " + sd.CURRENT_USER.email);
+  $('body').append("<br><br>your email from the client-side!<br> " + sd.CURRENT_USER.email);
+  return $('a.logout').click(function() {
+    return $.ajax({
+      url: '/users/sign_out',
+      type: 'DELETE',
+      success: function() {
+        return window.location = '/';
+      },
+      error: function(xhr, status, error) {
+        return alert(error);
+      }
+    });
+  });
 });
 
 

--- a/index.coffee
+++ b/index.coffee
@@ -63,7 +63,7 @@ initApp = ->
   app.get opts.twitterCallbackPath, socialAuth('twitter'), socialSignup('twitter')
   app.get opts.facebookCallbackPath, socialAuth('facebook'), socialSignup('facebook')
   app.get opts.twitterLastStepPath, loginBeforeTwitterLastStep
-  app.get opts.logoutPath, logout
+  app.delete opts.logoutPath, logout
   app.post opts.twitterLastStepPath, submitTwitterLastStep
   app.use headerLogin
   app.use addLocals

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -11,7 +11,7 @@ describe 'Artsy Passport integration', ->
   before (done) ->
     app.listen 5000, done
 
-  it 'can log in with email and password', (done) ->
+  it 'can log in and log out with email and password', (done) ->
     Browser.visit 'http://localhost:5000', (e, browser) ->
       browser
         .fill('email', ARTSY_EMAIL)
@@ -19,7 +19,11 @@ describe 'Artsy Passport integration', ->
         .pressButton "Login", ->
           browser.html().should.containEql '<h1>Hello'
           browser.html().should.containEql ARTSY_EMAIL
-          done()
+          browser
+            .clickLink "Logout", ->
+              browser.reload ->
+                browser.html().should.containEql '<h1>Login'
+                done()
 
   it 'can log in with facebook', (done) ->
     Browser.visit 'http://localhost:5000', (e, browser) ->


### PR DESCRIPTION
We have a security vulnerability whereas you can embed an `<img src='https://artsy.net/users/sign_out'>` into, say an email and get users logged out of Artsy just by opening that email. This was fixed on api.artsy.net by inserting a logout form (in https://github.com/artsy/gravity/pull/8376). This is the first step of fixing it in artsy.net by disallowing GET /users/sign_out.

cc: @craigspaeth 
