### PR TITLE
@craigspaeth - signupRedirect option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ app.use artsyPassport
   SECURE_ARTSY_URL: # SSL Artsy url e.g. https://artsy.net
   XAPP_TOKEN: # Artsy X-APP Token
   APP_URL: # Url pointing back to your app e.g. http://flare.artsy.net
+  signupRedirect: '/personalize' # path to redirect a user to after signup
   facebookPath: '/users/auth/facebook' # Url to point your facebook button to
   twitterPath: '/users/auth/twitter' # Url to point your twitter button to
   loginPath: '/users/sign_in' # POST `email` and `password` to this path to login

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ app.use artsyPassport
   SECURE_ARTSY_URL: # SSL Artsy url e.g. https://artsy.net
   XAPP_TOKEN: # Artsy X-APP Token
   APP_URL: # Url pointing back to your app e.g. http://flare.artsy.net
-  signupRedirect: '/personalize' # path to redirect a user to after signup
+  signupRedirect: '/personalize' # sets a session variable `redirectTo` that can be handled on your app after signup
   facebookPath: '/users/auth/facebook' # Url to point your facebook button to
   twitterPath: '/users/auth/twitter' # Url to point your twitter button to
   loginPath: '/users/sign_in' # POST `email` and `password` to this path to login

--- a/index.coffee
+++ b/index.coffee
@@ -161,6 +161,7 @@ accessTokenCallback = (req, done, params) ->
         .post(opts.SECURE_ARTSY_URL + '/api/v1/user')
         .send(params)
         .end (err, res) ->
+          req.session.redirectTo = opts.signupRedirect
           err = (err or res?.body.error_description or res?.body.error)
           done err or { message: 'artsy-passport: created user from social', user: res.body }
 

--- a/index.coffee
+++ b/index.coffee
@@ -28,6 +28,7 @@ opts =
   facebookCallbackPath: '/users/auth/facebook/callback'
   twitterLastStepPath: '/users/auth/twitter/email'
   logoutPath: '/users/sign_out'
+  signupRedirect: '/'
   userKeys: ['id', 'type', 'name', 'email', 'phone', 'lab_features',
              'default_profile_id', 'has_partner_access', 'collector_level']
   twitterSignupTempEmail: (token) -> "#{hash(token).substr 0, 12}@artsy.tmp"
@@ -62,7 +63,7 @@ initApp = ->
 initPassport = ->
   passport.serializeUser serializeUser
   passport.deserializeUser deserializeUser
-  passport.use new LocalStrategy { usernameField: 'email' }, artsyCallback
+  passport.use new LocalStrategy { usernameField: 'email', passReqToCallback: true }, artsyCallback
   passport.use new FacebookStrategy
     clientID: opts.FACEBOOK_ID
     clientSecret: opts.FACEBOOK_SECRET
@@ -80,14 +81,14 @@ initPassport = ->
 #
 # Passport callbacks
 #
-artsyCallback = (username, password, done) ->
+artsyCallback = (req, username, password, done) ->
   request.get("#{opts.SECURE_ARTSY_URL}/oauth2/access_token").query(
     client_id: opts.ARTSY_ID
     client_secret: opts.ARTSY_SECRET
     grant_type: 'credentials'
     email: username
     password: password
-  ).end accessTokenCallback(done)
+  ).end accessTokenCallback(req, done)
 
 facebookCallback = (req, token, refreshToken, profile, done) ->
   if req.user
@@ -104,7 +105,7 @@ facebookCallback = (req, token, refreshToken, profile, done) ->
       grant_type: 'oauth_token'
       oauth_token: token
       oauth_provider: 'facebook'
-    ).end accessTokenCallback(done,
+    ).end accessTokenCallback(req, done,
       oauth_token: token
       provider: 'facebook'
       name: profile?.displayName
@@ -127,7 +128,7 @@ twitterCallback = (req, token, tokenSecret, profile, done) ->
       oauth_token: token
       oauth_token_secret: tokenSecret
       oauth_provider: 'twitter'
-    ).end accessTokenCallback(done,
+    ).end accessTokenCallback(req, done,
       oauth_token: token
       oauth_token_secret: tokenSecret
       provider: 'twitter'
@@ -135,7 +136,7 @@ twitterCallback = (req, token, tokenSecret, profile, done) ->
       name: profile?.displayName
     )
 
-accessTokenCallback = (done, params) ->
+accessTokenCallback = (req, done, params) ->
   return (e, res) ->
 
     # Catch the various forms of error Artsy could encounter

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -75,8 +75,8 @@ describe 'Artsy Passport methods', ->
   describe '#accessTokenCallback', ->
 
     before ->
-      opts = @artsyPassport.__get__ 'opts'
-      opts.CurrentUser = ->
+      @opts = @artsyPassport.__get__ 'opts'
+      @opts.CurrentUser = ->
       @accessTokenCallback = @artsyPassport.__get__ 'accessTokenCallback'
       @request = @artsyPassport.__get__ 'request'
       @req = session: {}
@@ -98,6 +98,7 @@ describe 'Artsy Passport methods', ->
         end = sinon.stub()
         @done = sinon.stub()
         @request.post.returns send: => end: end
+        console.log 'req', @req
         @accessTokenCallback(@req, @done, { xapp_token: 'foobar' })(
           null,
           { body: error_description: 'no account linked' }
@@ -113,6 +114,11 @@ describe 'Artsy Passport methods', ->
       it 'passes a custom error for our socialSignup callback to redirect to login', ->
         @end null, body: { name: 'Craig' }
         @done.args[0][0].message.should.equal 'artsy-passport: created user from social'
+
+      it 'sets the redirectTo session var if a user is created', ->
+        @end null, body: { name: 'Cab' }
+        @req.session.redirectTo.should.equal @opts.signupRedirect
+
 
   describe '#socialSignup', ->
 

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -98,7 +98,6 @@ describe 'Artsy Passport methods', ->
         end = sinon.stub()
         @done = sinon.stub()
         @request.post.returns send: => end: end
-        console.log 'req', @req
         @accessTokenCallback(@req, @done, { xapp_token: 'foobar' })(
           null,
           { body: error_description: 'no account linked' }

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -79,12 +79,13 @@ describe 'Artsy Passport methods', ->
       opts.CurrentUser = ->
       @accessTokenCallback = @artsyPassport.__get__ 'accessTokenCallback'
       @request = @artsyPassport.__get__ 'request'
+      @req = session: {}
 
     it 'is okay if there is no response object', ->
-      @accessTokenCallback(->)({ bad: 'news' }, null)
+      @accessTokenCallback(@req, ->)({ bad: 'news' }, null)
 
     it 'sends error messages in an error object', (done) ->
-      @accessTokenCallback((err) ->
+      @accessTokenCallback(@req, (err) ->
         err.should.containEql 'Epic Fail'
         done()
       )(null, { body: error_description: 'Epic Fail' })
@@ -97,7 +98,7 @@ describe 'Artsy Passport methods', ->
         end = sinon.stub()
         @done = sinon.stub()
         @request.post.returns send: => end: end
-        @accessTokenCallback(@done, { xapp_token: 'foobar' })(
+        @accessTokenCallback(@req, @done, { xapp_token: 'foobar' })(
           null,
           { body: error_description: 'no account linked' }
         )


### PR DESCRIPTION
This gives the ability to pass a signupRedirect option:

```
app.use artsyPassport _.extend config,
    CurrentUser: CurrentUser
    signupRedirect: '/personalize'
```

Social auth seems to redirect multiple times so this will only set a session variable that can be handled on the app side after the user is fully logged in.