### PR TITLE
@dzucconi: CSRF required for login form and trust token login support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ app.use artsyPassport
   TWITTER_SECRET: # Twitter consumer secret
   ARTSY_ID: # Artsy client id
   ARTSY_SECRET: # Artsy client secret
-  SECURE_ARTSY_URL: # SSL Artsy url e.g. https://artsy.net
+  ARTSY_URL: # SSL Artsy url e.g. https://artsy.net
   XAPP_TOKEN: # Artsy X-APP Token
   APP_URL: # Url pointing back to your app e.g. http://flare.artsy.net
   signupRedirect: '/personalize' # sets a session variable `redirectTo` that can be handled on your app after signup
@@ -65,6 +65,7 @@ form( action='/users/sign_in', method='POST' )
   input( name='name' )
   input( name='email' )
   input( name='password' )
+  input( type="hidden" name="_csrf" value=csrfToken )
   button( type='submit' ) Signup
 ````
 
@@ -155,7 +156,7 @@ module.exports =
   TWITTER_SECRET: ''
   ARTSY_ID: ''
   ARTSY_SECRET: ''
-  SECURE_ARTSY_URL: 'https://api.artsy.net'
+  ARTSY_URL: 'https://api.artsy.net'
   APP_URL: 'http://local.artsy.net:3000'
   # An Artsy user that's linked to Facebook and Twitter
   ARTSY_EMAIL: 'craig@artsy.net'

--- a/example/client.coffee
+++ b/example/client.coffee
@@ -1,13 +1,24 @@
 sd = require('sharify').data
 
 $ ->
-  $('body').append "<br><br>your email from the client-side!<br> " + sd.CURRENT_USER.email
-
-  $('a.logout').click ->
-    $.ajax
-      url: '/users/sign_out'
-      type: 'DELETE'
-      success: ->
-        window.location = '/'
-      error: (xhr, status, error) ->
-        alert(error)
+  if sd.CURRENT_USER
+    $('body').append "<br><br>your email from the client-side!<br> " + sd.CURRENT_USER.email
+    $('a.logout').click ->
+      $.ajax
+        url: '/users/sign_out'
+        type: 'DELETE'
+        success: ->
+          window.location = '/'
+        error: (xhr, status, error) ->
+          alert(error)
+  else
+    $('#trust button').click ->
+      $.ajax
+        type: 'POST'
+        url: "#{sd.ARTSY_URL}/api/v1/me/trust_token"
+        headers: 'x-access-token': $('#trust input').val().trim()
+        error: (e) ->
+          alert 'Error!'
+          console.warn e
+        success: ({ trust_token }) ->
+          window.location = "http://#{location.host}?trust_token=#{trust_token}"

--- a/example/nocsrf.jade
+++ b/example/nocsrf.jade
@@ -15,7 +15,6 @@ html(lang="en")
       form( action='/users/sign_in', method='POST' )
         h3 Login via Email
         mixin email-password
-        input( type="hidden" name="_csrf" value=csrfToken )
         button( type='submit' ) Login
     hr
     #signup
@@ -28,13 +27,3 @@ html(lang="en")
         input( name='name', placeholder='Name...' )
         mixin email-password
         button( type='submit' ) Signup
-    hr
-    #trust
-      h1 Trust token login
-      label Access token&nbsp;
-        input
-        | &nbsp;
-      button.trust-login Login
-    != sharify.script()
-    script( src='//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js' )
-    script( src='/client.js' )

--- a/example/public/client.js
+++ b/example/public/client.js
@@ -4,21 +4,41 @@ var sd;
 sd = require('sharify').data;
 
 $(function() {
-  $('body').append("<br><br>your email from the client-side!<br> " + sd.CURRENT_USER.email);
-  return $('a.logout').click(function() {
-    return $.ajax({
-      url: '/users/sign_out',
-      type: 'DELETE',
-      success: function() {
-        return window.location = '/';
-      },
-      error: function(xhr, status, error) {
-        return alert(error);
-      }
+  if (sd.CURRENT_USER) {
+    $('body').append("<br><br>your email from the client-side!<br> " + sd.CURRENT_USER.email);
+    return $('a.logout').click(function() {
+      return $.ajax({
+        url: '/users/sign_out',
+        type: 'DELETE',
+        success: function() {
+          return window.location = '/';
+        },
+        error: function(xhr, status, error) {
+          return alert(error);
+        }
+      });
     });
-  });
+  } else {
+    return $('#trust button').click(function() {
+      return $.ajax({
+        type: 'POST',
+        url: sd.ARTSY_URL + "/api/v1/me/trust_token",
+        headers: {
+          'x-access-token': $('#trust input').val().trim()
+        },
+        error: function(e) {
+          alert('Error!');
+          return console.warn(e);
+        },
+        success: function(arg) {
+          var trust_token;
+          trust_token = arg.trust_token;
+          return window.location = "http://" + location.host + "?trust_token=" + trust_token;
+        }
+      });
+    });
+  }
 });
-
 
 
 },{"sharify":2}],2:[function(require,module,exports){

--- a/index.js
+++ b/index.js
@@ -1,9 +1,2 @@
-var coffee = require("coffee-script");
-var File = require("fs");
-if (!require.extensions[".coffee"]) {
-  require.extensions[".coffee"] = function (module, filename) {
-    var source = coffee.compile(File.readFileSync(filename, "utf8"));
-    return module._compile(source, filename);
-  };
-}
+require('coffee-script/register');
 module.exports = require("./index.coffee");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artsy-passport",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "description": "Wires up the common auth handlers for Artsy's [Ezel](ezeljs.com)-based apps using [passport](http://passportjs.org/).",
   "keywords": [
     "artsy",
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "coffee-script": "^1.9.2",
+    "csurf": "^1.8.3",
     "express": "^4.12.3",
     "passport": "^0.2.1",
     "passport-facebook": "^2.0.0",
@@ -50,8 +51,8 @@
     "backbone-super-sync": "*",
     "browserify": "*",
     "coffeeify": "*",
-    "artsy-xapp-middleware": "*",
-    "zombie": "*",
+    "artsy-xapp": "*",
+    "zombie": "2.x",
     "rewire": "*"
   }
 }


### PR DESCRIPTION
This copy + pastes your trustTokenMiddleware code from Force and adds csrf middleware. Since the csrf is a breaking change anyways I decided to rename `SECURE_ARTSY_URL` to just `ARTSY_URL` which aligns with [artsy-xapp](https://github.com/artsy/artsy-xapp) and since we're SSL everything now the former seems redundant.