### PR TITLE
@broskoski: State param csrf check for Twitter auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ compile:
 	$(BIN)/browserify -t coffeeify example/client.coffee > example/public/client.js
 
 example: compile
-	$(BIN)/coffee example/index.coffee
+	open http://local.artsy.net:3000 && $(BIN)/coffee example/index.coffee
 
 .PHONY: test example

--- a/example/index.coffee
+++ b/example/index.coffee
@@ -70,6 +70,10 @@ setup = (app) ->
   app.delete '/users/sign_out', (req, res) ->
     res.send JSON.stringify(status: 'ok')
 
+  # Error handler
+  app.use (err, req, res, next) ->
+    console.log 'end'
+    res.send err.stack
   return unless module is require.main
   artsyXapp.on('error', (e) -> console.warn(e); process.exit(1)).init
     url: config.ARTSY_URL

--- a/example/index.coffee
+++ b/example/index.coffee
@@ -72,7 +72,6 @@ setup = (app) ->
 
   # Error handler
   app.use (err, req, res, next) ->
-    console.log 'end'
     res.send err.stack
   return unless module is require.main
   artsyXapp.on('error', (e) -> console.warn(e); process.exit(1)).init

--- a/index.coffee
+++ b/index.coffee
@@ -234,10 +234,8 @@ socialAuth = (provider) ->
     # So we implement it ourselves ( -__- )
     # https://twittercommunity.com/t/is-the-state-parameter-supported/1889
     if provider is 'twitter' and not req.query.state
-      console.log 'set state', req.path
       req.session.twitterState = hash Math.random().toString()
     if req.path is opts.twitterCallbackPath and req.query.state isnt req.session.twitterState
-      console.log 'check state', req.path
       err = new Error("Must pass a valid `state` param.")
       return next err
     passport.authenticate(provider,

--- a/index.coffee
+++ b/index.coffee
@@ -224,12 +224,26 @@ afterLocalAuth = (req, res ,next) ->
 socialAuth = (provider) ->
   (req, res, next) ->
     return next("#{provider} denied") if req.query.denied
+    # CSRF protection for Facebook account linking
     if req.path is opts.facebookPath and req.user and
        req.query.state isnt hash(req.user.get 'accessToken')
       err = new Error("Must pass a `state` query param equal to a sha1 hash" +
         "of the user's access token to link their account.")
       return next err
-    passport.authenticate(provider, scope: 'email')(req, res, next)
+    # Twitter OAuth 1 doesn't support `state` param csrf out of the box.
+    # So we implement it ourselves ( -__- )
+    # https://twittercommunity.com/t/is-the-state-parameter-supported/1889
+    if provider is 'twitter' and not req.query.state
+      console.log 'set state', req.path
+      req.session.twitterState = hash Math.random().toString()
+    if req.path is opts.twitterCallbackPath and req.query.state isnt req.session.twitterState
+      console.log 'check state', req.path
+      err = new Error("Must pass a valid `state` param.")
+      return next err
+    passport.authenticate(provider,
+      scope: 'email'
+      callbackURL: "#{opts.APP_URL}#{opts.twitterCallbackPath}?state=#{req.session.twitterState}" if provider is 'twitter'
+    )(req, res, next)
 
 # We have to hack around passport by capturing a custom error message that
 # indicates we've created a user in one of passport's social callbacks. If we

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "browserify": "*",
     "coffeeify": "*",
     "artsy-xapp": "*",
-    "zombie": "2.x",
+    "zombie": "*",
     "rewire": "*"
   }
 }

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -181,6 +181,13 @@ describe 'Artsy Passport methods', ->
       @socialAuth('facebook')(@req, @res, @next)
       @passport.authenticate.args[0][0].should.equal 'facebook'
 
+    it 'requires a state param thats the same as generated on session', ->
+      @req.session = twitterState: 'foobarbaz'
+      @req.path = '/users/auth/twitter/callback'
+      @req.query.state = 'moo'
+      @socialAuth('twitter')(@req, @res, @next)
+      @next.args[0][0].toString().should.containEql 'Must pass a valid `state`'
+
     it 'requires a state param equal to the sha1 of the access token', ->
       @req.user = new Backbone.Model accessToken: 'foobarbaz'
       @req.path = '/users/auth/facebook'


### PR DESCRIPTION
Twitter [doesn't support OAuth2 for users](https://twittercommunity.com/t/is-the-state-parameter-supported/1889), so we have to add this `state` param csrf thing ourselves (it's just a `state: true` passport config for Facebook). Basically the gist is you generate a token that you pass to Twitter before authorizing our Twitter app access and check that when Twitter sends you back to Artsy (at the `/users/auth/twitter/callback` callback url) it includes that token as a `state` query param.

Or at least that's what I think is involved [OAuth... ( -__- )](http://hueniverse.com/2012/07/26/oauth-2-0-and-the-road-to-hell/).—we'll see if it passes our bounty program h4x0rz's approval.