### PR TITLE
@craigspaeth (cc @dzucconi): Address open redirect issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Artsy Passport
 
-Wires up the common auth handlers for Artsy's [Ezel](http://ezeljs.com)-based apps using [passport](http://passportjs.org/). Used internally at Artsy to DRY up authentication code.
+Wires up the common auth handlers, and related security concerns, for Artsy's [Ezel](http://ezeljs.com)-based apps using [passport](http://passportjs.org/). Used internally at Artsy to DRY up authentication code.
 
 ## Setup
 
@@ -36,7 +36,7 @@ app.use artsyPassport
   ARTSY_SECRET: # Artsy client secret
   ARTSY_URL: # SSL Artsy url e.g. https://artsy.net
   APP_URL: # Url pointing back to your app e.g. http://flare.artsy.net
-  
+
   # Defaults you probably don't need to touch
   # -----------------------------------------
 
@@ -177,6 +177,17 @@ app.get '/', (req, res) ->
 ````
 
 _These forms of user will be null if they're not logged in._
+
+## Sanitize Redirect
+
+If you implement a fancier auth flow that involves client-side redirecting back, you may find this helper useful in avoiding ["open redirect"](https://github.com/artsy/artsy-passport/issues/68) attacks.
+
+````coffeescript
+{ sanitizeRedirect } = require 'artsy-passport'
+
+location.href = sanitizeRedirect "http://artsy.net%0D%0Aattacker.com/"
+# Notices the url isn't pointing at artsy.net, so just redirects to /
+````
 
 ## Contributing
 

--- a/lib/app/redirectback.coffee
+++ b/lib/app/redirectback.coffee
@@ -2,39 +2,7 @@
 # Redirects back based on query params, session, or w/e else.
 # Code stolen from Force, thanks @dzucconi!
 #
-
-_ = require 'underscore'
-{ parse } = require 'url'
-
-redirectFallback = '/'
-whitelistHosts = [
-  'internal'
-  'localhost'
-  'artsy.net'
-]
-whitelistProtocols = [
-  'http:'
-  'https:'
-  null
-]
-
-hasStatus = (args) ->
-  args.length is 2 and typeof args[0] is 'number'
-
-bareHost = (hostname) ->
-  return 'internal' unless hostname?
-  _.last(hostname.split('.'), subdomainOffset = 2).join '.'
-
-normalizeAddress = (address) ->
-  address.replace /^http(s?):\/+/, 'http://'
-
-safeAddress = (address) ->
-  parsed = parse(normalizeAddress(address), false, true)
-  _.contains(whitelistProtocols, parsed.protocol) and
-  _.contains(whitelistHosts, bareHost(parsed.hostname))
-
-sanitizeRedirect = (address) ->
-  if safeAddress(address) then address else redirectFallback
+sanitizeRedirect = require './sanitize_redirect'
 
 module.exports = (req, res) ->
   url = req.body['redirect-to'] or

--- a/lib/app/sanitize_redirect.coffee
+++ b/lib/app/sanitize_redirect.coffee
@@ -1,0 +1,38 @@
+#
+# Cleans out urls so they are safe to redirect to inside of an artsy.net app.
+# Code stolen from Force, thanks @dzucconi!
+#
+_ = require 'underscore'
+{ parse } = require 'url'
+
+redirectFallback = '/'
+whitelistHosts = [
+  'internal'
+  'localhost'
+  'artsy.net'
+]
+whitelistProtocols = [
+  'http:'
+  'https:'
+  null
+]
+
+hasStatus = (args) ->
+  args.length is 2 and typeof args[0] is 'number'
+
+bareHost = (hostname) ->
+  return 'internal' unless hostname?
+  _.last(hostname.split('.'), subdomainOffset = 2).join '.'
+
+normalizeAddress = (address) ->
+  address
+    .replace /^http(s?):\/+/, 'http://'
+    .replace /\s/g, ''
+
+safeAddress = (address) ->
+  parsed = parse(normalizeAddress(address), false, true)
+  _.contains(whitelistProtocols, parsed.protocol) and
+  _.contains(whitelistHosts, bareHost(parsed.hostname))
+
+module.exports = (address) ->
+  if safeAddress(address) then address else redirectFallback

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -9,6 +9,7 @@ opts = require './options'
 setupApp = require './app'
 setupPassport = require './passport'
 artsyXapp = require 'artsy-xapp'
+sanitizeRedirect = require './app/sanitize_redirect'
 
 module.exports = (options) =>
   _.extend opts, options
@@ -16,3 +17,4 @@ module.exports = (options) =>
   setupApp()
 
 module.exports.options = opts
+module.exports.sanitizeRedirect = sanitizeRedirect

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artsy-passport",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Wires up the common auth handlers for Artsy's [Ezel](ezeljs.com)-based apps using [passport](http://passportjs.org/).",
   "keywords": [
     "artsy",

--- a/test/app/sanitize_redirect.coffee
+++ b/test/app/sanitize_redirect.coffee
@@ -1,0 +1,58 @@
+sinon = require 'sinon'
+{ sanitizeRedirect } = require '../../'
+
+describe 'sanitizeRedirect', ->
+  it 'lets artsy.net through', ->
+    sanitizeRedirect('http://artsy.net').should.equal 'http://artsy.net'
+
+  it 'lets artsy.net without a protocol through', ->
+    sanitizeRedirect('//artsy.net').should.equal '//artsy.net'
+
+  it 'lets artsy.net subdomains through', ->
+    sanitizeRedirect('http://2013.artsy.net').should.equal 'http://2013.artsy.net'
+
+  it 'lets artsy.net subdomains without a protocol through', ->
+    sanitizeRedirect('//2013.artsy.net').should.equal '//2013.artsy.net'
+
+  it 'lets relative paths through', ->
+    sanitizeRedirect('/path').should.equal '/path'
+
+  it 'lets deeply nested artsy.net subdomains through', ->
+    sanitizeRedirect('https://foo.2013.artsy.net').should.equal 'https://foo.2013.artsy.net'
+
+  it 'lets artsy.net links through', ->
+    sanitizeRedirect('https://artsy.net/about').should.equal 'https://artsy.net/about'
+
+  it 'lets localhost through', ->
+    sanitizeRedirect('http://localhost:3003/artwork/joe-piccillo-a-riposo').should.equal 'http://localhost:3003/artwork/joe-piccillo-a-riposo'
+
+  it 'lets internal paths through', ->
+    sanitizeRedirect('/log_in?redirect-to=/foo/bar').should.equal '/log_in?redirect-to=/foo/bar'
+
+  it 'blocks data urls', ->
+    sanitizeRedirect('data:text/html;base64,PHNjcmlwdD5hbGVydChsb2NhdGlvbi5oYXNoKTs8L3NjcmlwdD4=')[0].should.equal '/'
+
+  it 'blocks external links not whitelisted; redirects to root', ->
+    sanitizeRedirect('http://google.com').should.equal '/'
+
+  it 'blocks external links that lack protocol; redirects to root', ->
+    sanitizeRedirect('//google.com').should.equal '/'
+
+  it 'blocks other protocols; redirects to root', ->
+    sanitizeRedirect('ftp://google.com').should.equal '/'
+
+  it 'blocks other protocols; redirects to root', ->
+    sanitizeRedirect('javascript:alert(1);').should.equal '/'
+
+  it 'blocks malformed URLs (1)', ->
+    sanitizeRedirect('http:/google.com').should.equal '/'
+
+  it 'blocks malformed URLs (2)', ->
+    sanitizeRedirect('https:/google.com').should.equal '/'
+
+  it 'blocks malformed URLs (3)', ->
+    sanitizeRedirect('http:///google.com').should.equal '/'
+
+  it 'strips out whitespace', ->
+    sanitizeRedirect('''http://artsy.net
+    attacker.com/''').should.equal '/'


### PR DESCRIPTION
https://github.com/artsy/artsy-passport/issues/68

The problem here seems to be due to how client-side those whitespace characters are interpreted and how that gets through sanitizing... just stripping whitespace now and will re-introduce to Force. 

![image](https://cloud.githubusercontent.com/assets/555859/14864483/0c794a9a-0c88-11e6-9dfd-173d759167b6.png)
