### PR TITLE
@craigspaeth: Single sign on to Gravity after logging in

### DIFF
--- a/lib/app/redirectback.coffee
+++ b/lib/app/redirectback.coffee
@@ -5,9 +5,12 @@
 sanitizeRedirect = require './sanitize_redirect'
 
 module.exports = (req, res) ->
-  url = req.body['redirect-to'] or
-        req.query['redirect-to'] or
-        req.params.redirect_uri or
-        req.session.redirectTo or
-        '/'
-  res.redirect sanitizeRedirect(url)
+  url = sanitizeRedirect(
+    req.body['redirect-to'] or
+    req.query['redirect-to'] or
+    req.params.redirect_uri or
+    req.session.redirectTo or
+    '/'
+  )
+  res?.redirect url
+  return url

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artsy-passport",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "Wires up the common auth handlers for Artsy's [Ezel](ezeljs.com)-based apps using [passport](http://passportjs.org/).",
   "keywords": [
     "artsy",


### PR DESCRIPTION
This will use Gravity's trust_token login scheme to log a user in to Gravity after logging into Artsy Passport apps (Force + MG). This will be convenient for apps like CMS and Writer which use Gravity as an OAuth provider b/c it means a user who logs in to the Artsy website, should be able to seamlessly be logged into those apps as well.