### PR TITLE
@craigspaeth: assign the query redirect to session redirect so it is not lost

### DIFF
--- a/lib/app/lifecycle.coffee
+++ b/lib/app/lifecycle.coffee
@@ -59,6 +59,7 @@ crypto = require 'crypto'
         next()
 
 @beforeSocialAuth = (provider) -> (req, res, next) ->
+  req.session.redirectTo = req.query['redirect-to']
   options = {}
   options.scope = switch provider
     when 'linkedin' then ['r_basicprofile', 'r_emailaddress']

--- a/test/app/lifecycle.coffee
+++ b/test/app/lifecycle.coffee
@@ -103,6 +103,13 @@ describe 'lifecycle', ->
       @passport.authenticate.args[0][1].callbackURL
         .should.containEql "state=#{@req.session.twitterState}"
 
+    it 'sets session redirect', ->
+      @req.query['redirect-to'] = '/foobar'
+      @passport.authenticate.returns (req, res, next) -> next()
+      lifecycle.beforeSocialAuth('facebook')(@req, @res, @next)
+      @req.session.redirectTo.should.equal '/foobar'
+      @passport.authenticate.args[0][1].scope.should.equal 'email'
+
     it 'asks for linked in profile info'
 
     it 'asks for email scope if not linkedin'


### PR DESCRIPTION
 In the process of authenticating with the Facebook provide in passport the query redirect is lost [#4379](https://github.com/artsy/force/issues/4379). This assigns the value of the query redirect to the session redirect so that it persists.

This is my first stab at working in artsy-passport so let me know if I'm missing anything (or need to add more tests). 

cc: @broskoski 