### PR TITLE
@broskoski: CSRF protection on "one last step"

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ else
 h1 Just one more step
 pre!= error
 form( method='post', action=ap.twitterLastStepPath )
+  input( type="hidden" name="_csrf" value=csrfToken )
   input.bordered-input( name='email' )
   button( type='submit' ) Join Artsy
 ````

--- a/lib/app/index.coffee
+++ b/lib/app/index.coffee
@@ -39,7 +39,7 @@ module.exports = ->
   # Twitter "one last step" UI
   app.get '/', twitterLastStep.ensureEmail
   app.get opts.twitterLastStepPath, twitterLastStep.login
-  app.post opts.twitterLastStepPath, twitterLastStep.submit, twitterLastStep.error
+  app.post opts.twitterLastStepPath, csrf(cookie: true), twitterLastStep.submit, twitterLastStep.error
 
   # Logout middleware
   app.get opts.logoutPath, denyBadLogoutLinks, logout

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artsy-passport",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Wires up the common auth handlers for Artsy's [Ezel](ezeljs.com)-based apps using [passport](http://passportjs.org/).",
   "keywords": [
     "artsy",


### PR DESCRIPTION
When a user signs up through twitter they see this UI so we can collect their email

![image](https://cloud.githubusercontent.com/assets/555859/16883313/4d1ce84e-4a91-11e6-98bb-51279ff6b6e0.png)

One of dB's security researchers pointed out that there isn't CSRF protection on this—which could be exploited by...

1. User logs in to Artsy
2. User opens up email from Nigerian prince to attacker.com
3. User submits a form to send bitcoin to said prince on attacker.com
4. Said form actually POSTs to artsy.net/users/auth/twitter/email (the "one last step form endpoint) and has a hidden field with `name='email' value='haxor@nigerianprince.com'` 
5. User's email gets updated to haxor@nigerianprince.com and user gets redirected to Artsy's personalize flow b/c we don't enforce CSRF