### PR TITLE
@kanaabe: Add segment tracking to signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ app.use artsyPassport
   ARTSY_SECRET: # Artsy client secret
   ARTSY_URL: # SSL Artsy url e.g. https://artsy.net
   APP_URL: # Url pointing back to your app e.g. http://flare.artsy.net
+  SEGMENT_WRITE_KEY: # Segment write key to track signup
 
   # Defaults you probably don't need to touch
   # -----------------------------------------

--- a/lib/app/analytics.coffee
+++ b/lib/app/analytics.coffee
@@ -1,0 +1,21 @@
+opts = require '../options'
+Analytics = require 'analytics-node'
+
+@setCampaign = (req, res, next) ->
+  req.session.modalId = req.params.modal_id
+  req.session.acquisitionInitiative = req.params.acquisition_initiative
+  next()
+
+@trackSignup = (service) -> (req, res, next) ->
+  analytics = new Analytics opts.SEGMENT_WRITE_KEY
+  analytics.track
+    event: 'Created account'
+    userId: req.user.get 'id'
+    properties:
+      modal_id: req.session.modalId
+      acquisition_initiative: req.session.acquisitionInitiative
+      signup_service: service
+      user_id: req.user.get 'id'
+  req.session.modalId = null
+  req.session.acquisitionInitiative = null
+  next()

--- a/lib/app/analytics.coffee
+++ b/lib/app/analytics.coffee
@@ -2,11 +2,13 @@ opts = require '../options'
 Analytics = require 'analytics-node'
 
 @setCampaign = (req, res, next) ->
+  return next() unless opts.SEGMENT_WRITE_KEY
   req.session.modalId = req.params.modal_id
   req.session.acquisitionInitiative = req.params.acquisition_initiative
   next()
 
 @trackSignup = (service) -> (req, res, next) ->
+  return next() unless opts.SEGMENT_WRITE_KEY
   analytics = new Analytics opts.SEGMENT_WRITE_KEY
   analytics.track
     event: 'Created account'

--- a/lib/app/index.coffee
+++ b/lib/app/index.coffee
@@ -57,8 +57,8 @@ module.exports = ->
     trackSignup('facebook'),
     ssoAndRedirectBack
   app.get opts.linkedinCallbackPath,
-    trackSignup('linkedin'),
     afterSocialAuth('linkedin'),
+    trackSignup('linkedin'),
     ssoAndRedirectBack
 
   # Twitter "one last step" UI

--- a/lib/app/index.coffee
+++ b/lib/app/index.coffee
@@ -12,8 +12,16 @@ passport = require 'passport'
 app = express()
 opts = require '../options'
 twitterLastStep = require './twitter_last_step'
-{ onLocalLogin, onLocalSignup, beforeSocialAuth,
-  afterSocialAuth, ensureLoggedInOnAfterSignupPage, onError } = require './lifecycle'
+{
+  onLocalLogin,
+  onLocalSignup,
+  beforeSocialAuth,
+  afterSocialAuth,
+  ensureLoggedInOnAfterSignupPage,
+  onError,
+  ssoAndRedirectBack
+} = require './lifecycle'
+{ setCampaign, trackSignup } = require './analytics'
 { denyBadLogoutLinks, logout } = require './logout'
 { headerLogin, trustTokenLogin } = require './token_login'
 addLocals = require './locals'
@@ -25,21 +33,41 @@ module.exports = ->
   app.get '*', csrf(cookie: true)
 
   # Local email/password auth
-  app.post opts.loginPagePath, csrf(cookie: true), onLocalLogin
-  app.post opts.signupPagePath, onLocalSignup, onLocalLogin
+  app.post opts.loginPagePath,
+    csrf(cookie: true),
+    onLocalLogin,
+    ssoAndRedirectBack
+  app.post opts.signupPagePath,
+    setCampaign,
+    onLocalSignup,
+    onLocalLogin,
+    trackSignup('email'),
+    ssoAndRedirectBack
 
   # Twitter/Facebook OAuth
-  app.get opts.twitterPath, beforeSocialAuth('twitter')
-  app.get opts.facebookPath, beforeSocialAuth('facebook')
-  app.get opts.linkedinPath, beforeSocialAuth('linkedin')
-  app.get opts.twitterCallbackPath, afterSocialAuth('twitter')
-  app.get opts.facebookCallbackPath, afterSocialAuth('facebook')
-  app.get opts.linkedinCallbackPath, afterSocialAuth('linkedin')
+  app.get opts.twitterPath, setCampaign, beforeSocialAuth('twitter')
+  app.get opts.facebookPath, setCampaign, beforeSocialAuth('facebook')
+  app.get opts.linkedinPath, setCampaign, beforeSocialAuth('linkedin')
+  app.get opts.twitterCallbackPath,
+    afterSocialAuth('twitter'),
+    trackSignup('twitter'),
+    ssoAndRedirectBack
+  app.get opts.facebookCallbackPath,
+    afterSocialAuth('facebook'),
+    trackSignup('facebook'),
+    ssoAndRedirectBack
+  app.get opts.linkedinCallbackPath,
+    trackSignup('linkedin'),
+    afterSocialAuth('linkedin'),
+    ssoAndRedirectBack
 
   # Twitter "one last step" UI
   app.get '/', twitterLastStep.ensureEmail
   app.get opts.twitterLastStepPath, twitterLastStep.login
-  app.post opts.twitterLastStepPath, csrf(cookie: true), twitterLastStep.submit, twitterLastStep.error
+  app.post opts.twitterLastStepPath,
+    csrf(cookie: true),
+    twitterLastStep.submit,
+    twitterLastStep.error
 
   # Logout middleware
   app.get opts.logoutPath, denyBadLogoutLinks, logout

--- a/lib/app/lifecycle.coffee
+++ b/lib/app/lifecycle.coffee
@@ -16,22 +16,20 @@ crypto = require 'crypto'
 { parse, resolve } = require 'url'
 
 @onLocalLogin = (req, res, next) ->
-  return ssoAndRedirectBack req, res, next if req.user and not req.xhr
+  return next() if req.user and not req.xhr
   passport.authenticate('local') req, res, (err) ->
     if req.xhr
       if err
         res.send 500, { success: false, error: err.message }
       else
-        res.send { success: true, user: req.user.toJSON() }
+        next()
     else
       if err?.response?.body?.error_description is 'invalid email or password'
         res.redirect opts.loginPagePath + '?error=Invalid email or password.'
       else if err
         next err
-      else if req.artsyPassportSignedUp
-        res.redirect opts.afterSignupPagePath
       else
-        ssoAndRedirectBack req, res, next
+        next()
 
 @onLocalSignup = (req, res, next) ->
   req.artsyPassportSignedUp = true
@@ -52,7 +50,8 @@ crypto = require 'crypto'
         else
           res.redirect opts.signupPagePath + "?error=#{msg}"
       else if err and req.xhr
-        res.send 500, { success: false, error: err.message }
+        msg = err.response?.body?.error or err.message
+        res.send 500, { success: false, error: msg }
       else if err
         next new Error err
       else
@@ -113,7 +112,7 @@ crypto = require 'crypto'
     else if req.artsyPassportSignedUp
       res.redirect opts.afterSignupPagePath
     else
-      ssoAndRedirectBack req, res, next
+      next()
 
 @ensureLoggedInOnAfterSignupPage = (req, res, next) ->
   res.redirect opts.loginPagePath unless req.user?
@@ -125,7 +124,8 @@ crypto = require 'crypto'
   else
     next err
 
-ssoAndRedirectBack = (req, res, next) ->
+@ssoAndRedirectBack = (req, res, next) ->
+  return res.send { success: true, user: req.user.toJSON() } if req.xhr
   parsed = parse redirectBack req
   parsed = parse resolve opts.APP_URL, parsed.path unless parsed.hostname
   domain = parsed.hostname?.split('.').slice(1).join('.')
@@ -138,4 +138,3 @@ ssoAndRedirectBack = (req, res, next) ->
       res.redirect "#{opts.ARTSY_URL}/users/sign_in" +
         "?trust_token=#{sres.body.trust_token}" +
         "&redirect_uri=#{parsed.href}"
-

--- a/lib/app/redirectback.coffee
+++ b/lib/app/redirectback.coffee
@@ -2,6 +2,7 @@
 # Redirects back based on query params, session, or w/e else.
 # Code stolen from Force, thanks @dzucconi!
 #
+opts = require '../options'
 sanitizeRedirect = require './sanitize_redirect'
 
 module.exports = (req, res) ->

--- a/lib/app/redirectback.coffee
+++ b/lib/app/redirectback.coffee
@@ -6,6 +6,7 @@ sanitizeRedirect = require './sanitize_redirect'
 
 module.exports = (req, res) ->
   url = sanitizeRedirect(
+    (opts.afterSignupPagePath if req.artsyPassportSignedUp) or
     req.body['redirect-to'] or
     req.query['redirect-to'] or
     req.params.redirect_uri or

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artsy-passport",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Wires up the common auth handlers for Artsy's [Ezel](ezeljs.com)-based apps using [passport](http://passportjs.org/).",
   "keywords": [
     "artsy",
@@ -29,6 +29,7 @@
     "example": "sleep 3 && open http://local.artsy.net:4000 & npm run compile && coffee example/index.coffee"
   },
   "dependencies": {
+    "analytics-node": "^2.1.0",
     "async": "^1.5.0",
     "coffee-script": "^1.9.2",
     "csurf": "^1.8.3",

--- a/test/app/analytics.coffee
+++ b/test/app/analytics.coffee
@@ -1,0 +1,25 @@
+sinon = require 'sinon'
+rewire = require 'rewire'
+analytics = rewire '../../lib/app/analytics'
+
+describe 'analytics', ->
+
+  beforeEach ->
+    analytics.__set__ 'opts', SEGMENT_WRITE_KEY: 'foobar'
+    scope = this
+    analytics.__set__ 'Analytics', class Analytics
+      constructor: ->
+        scope.analytics = this
+      track: sinon.stub()
+    @req = { session: {}, query: {}, user: { get: -> 'foo' } }
+    @res = { locals: { sd: {} } }
+    @next = sinon.stub()
+
+  it 'tracks signup', ->
+    analytics.trackSignup('email') @req, @res, @next
+    @analytics.track.args[0][0].properties.signup_service.should.equal 'email'
+
+  it 'passes modal id along', ->
+    @req.session.modalId = 'moo'
+    analytics.trackSignup('email') @req, @res, @next
+    @analytics.track.args[0][0].properties.modal_id.should.equal 'moo'


### PR DESCRIPTION
This adds Segment's node library to implement signup tracking at a granular, server-side, level. This is going to be important for user acquisition initiatives on the Collector Experience team. cc @anipetrov 