### PR TITLE
@kanaabe: Fix to pass along modal_id and acquisition_initiative via req.body instead

### DIFF
--- a/lib/app/analytics.coffee
+++ b/lib/app/analytics.coffee
@@ -3,21 +3,23 @@ Analytics = require 'analytics-node'
 
 @setCampaign = (req, res, next) ->
   return next() unless opts.SEGMENT_WRITE_KEY
-  req.session.modalId = req.params.modal_id
-  req.session.acquisitionInitiative = req.params.acquisition_initiative
+  req.session.modalId = req.body.modal_id
+  req.session.acquisitionInitiative = req.body.acquisition_initiative
   next()
 
 @trackSignup = (service) -> (req, res, next) ->
+  modalId = req.session.modalId
+  acquisitionInitiative = req.session.acquisitionInitiative
+  delete req.session.acquisitionInitiative
+  delete req.session.modalId
   return next() unless opts.SEGMENT_WRITE_KEY
   analytics = new Analytics opts.SEGMENT_WRITE_KEY
   analytics.track
     event: 'Created account'
     userId: req.user.get 'id'
     properties:
-      modal_id: req.session.modalId
-      acquisition_initiative: req.session.acquisitionInitiative
+      modal_id: modalId
+      acquisition_initiative: acquisitionInitiative
       signup_service: service
       user_id: req.user.get 'id'
-  req.session.modalId = null
-  req.session.acquisitionInitiative = null
   next()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artsy-passport",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Wires up the common auth handlers for Artsy's [Ezel](ezeljs.com)-based apps using [passport](http://passportjs.org/).",
   "keywords": [
     "artsy",


### PR DESCRIPTION
I had originally tried using Express'es [req.param()](http://expressjs.com/en/api.html#req.param) to pull out either the body or query params, then realized it was deprecated, so I naively used `req.params` instead, which is meant only for routing params like `/artwork/:id`. Derp. This just uses `req.body` because signing up would always be a POST request anyways. (I'll point out how this fits in, in my Force/MG PR coming soon).