### PR TITLE
@craigspaeth => Allow social auth to skip onboarding

### DIFF
--- a/lib/app/lifecycle.coffee
+++ b/lib/app/lifecycle.coffee
@@ -59,6 +59,7 @@ crypto = require 'crypto'
 
 @beforeSocialAuth = (provider) -> (req, res, next) ->
   req.session.redirectTo = req.query['redirect-to']
+  req.session.skipOnboarding = req.query['skip-onboarding']
   options = {}
   options.scope = switch provider
     when 'linkedin' then ['r_basicprofile', 'r_emailaddress']
@@ -109,7 +110,7 @@ crypto = require 'crypto'
       res.redirect opts.settingsPagePath
     else if req.artsyPassportSignedUp and provider is 'twitter'
       res.redirect opts.twitterLastStepPath
-    else if req.artsyPassportSignedUp
+    else if req.artsyPassportSignedUp and !req.session.skipOnboarding
       res.redirect opts.afterSignupPagePath
     else
       next()

--- a/lib/app/redirectback.coffee
+++ b/lib/app/redirectback.coffee
@@ -7,7 +7,7 @@ sanitizeRedirect = require './sanitize_redirect'
 
 module.exports = (req, res) ->
   url = sanitizeRedirect(
-    (opts.afterSignupPagePath if req.artsyPassportSignedUp) or
+    (opts.afterSignupPagePath if req.artsyPassportSignedUp and !req.session.skipOnboarding) or
     req.body['redirect-to'] or
     req.query['redirect-to'] or
     req.params.redirect_uri or


### PR DESCRIPTION
I think https://github.com/artsy/artsy-passport/commit/6a10788e53e6efd932a0aff9c711f23e039dc90c may have included a regression, where we can't skip onboarding during social auth.

You can see this in production now by clicking 'Bid' on an auction work and signing up with Facebook. You get dumped into the personalize flow and never make it back to the bid screen. I'm pretty sure this used to work, and that recent commit looks suspicious.

For the artist page CTA, I also want the ability to skip onboarding after a social signup, so this just adds support for a `skip-onboarding=true` query param.