### PR TITLE
@craigspaeth - Remove last step routing

### DIFF
--- a/lib/app/index.coffee
+++ b/lib/app/index.coffee
@@ -11,7 +11,6 @@ csrf = require 'csurf'
 passport = require 'passport'
 app = express()
 opts = require '../options'
-twitterLastStep = require './twitter_last_step'
 {
   onLocalLogin,
   onLocalSignup,
@@ -63,11 +62,6 @@ module.exports = ->
 
   # Twitter "one last step" UI
   app.get '/', twitterLastStep.ensureEmail
-  app.get opts.twitterLastStepPath, twitterLastStep.login
-  app.post opts.twitterLastStepPath,
-    csrf(cookie: true),
-    twitterLastStep.submit,
-    twitterLastStep.error
 
   # Logout middleware
   app.get opts.logoutPath, denyBadLogoutLinks, logout

--- a/lib/app/twitter_last_step.coffee
+++ b/lib/app/twitter_last_step.coffee
@@ -21,33 +21,3 @@ opts = require '../options'
   passport.authenticate('twitter',
     callbackURL: "#{opts.APP_URL}#{opts.twitterLastStepPath}"
   )(req, res, next)
-
-@submit = (req, res, next) ->
-  return next new Error "No user" unless req.user
-  return next new Error "No email provided" unless req.body.email?
-  request.put("#{opts.ARTSY_URL}/api/v1/me").send(
-    email: req.body.email
-    email_confirmation: req.body.email
-    access_token: req.user.get('accessToken')
-  ).end (err, r) ->
-    return next err if err
-    # To work around an API caching bug we send another empty PUT and
-    # update the current user.
-    request.put("#{opts.ARTSY_URL}/api/v1/me").send(
-      access_token: req.user.get('accessToken')
-    ).end (err, r) ->
-      return next err if err
-      req.login req.user.set(r.body), (err) ->
-        return next err if err
-        res.redirect opts.afterSignupPagePath
-
-@error = (err, req, res, next) ->
-  return next() if err.text?.match 'Error from MailChimp API'
-  msg = err.response.body?.error or err.message or err.toString()
-  if msg is 'User Already Exists'
-    href = "#{opts.logoutPath}?redirect-to=#{opts.loginPagePath}"
-    msg = "An account with this email address already exists. If this is " +
-          "your account please " +
-          "log in to Artsy with your email and password, and link your Twitter account" +
-          "in your settings instead."
-  res.redirect opts.twitterLastStepPath + '?error=' + msg


### PR DESCRIPTION
Re: @mzikherman 's idea here: https://github.com/artsy/force/pull/767

I might be thinking about this wrong, but the idea is to:
- Keep `twitterLastStepPath` as an option so we can properly route users who try to log in with Twitter and don't have an account (this would redirect them to `/sign_up` with an error message pre-filled.
- Keep `ensureEmail` and the `login` fallback (which will redirect the user to the `twitterLastStepPath` and subsequently `/sign_up`
- Delete the rest.

What do you think Mr. Secretary of Artsy Passport?