### PR TITLE
@broskoski: Pass user agent through signup and login

### DIFF
--- a/lib/app/lifecycle.coffee
+++ b/lib/app/lifecycle.coffee
@@ -35,7 +35,7 @@ crypto = require 'crypto'
   req.artsyPassportSignedUp = true
   request
     .post(opts.ARTSY_URL + '/api/v1/user')
-    .set('X-Xapp-Token': artsyXapp.token)
+    .set('X-Xapp-Token': artsyXapp.token, 'User-Agent': req.get 'user-agent')
     .send(
       name: req.body.name
       email: req.body.email

--- a/lib/passport/callbacks.coffee
+++ b/lib/passport/callbacks.coffee
@@ -10,91 +10,106 @@ opts = require '../options'
 artsyXapp = require 'artsy-xapp'
 
 @local = (req, username, password, done) ->
-  request.post("#{opts.ARTSY_URL}/oauth2/access_token").query(
-    client_id: opts.ARTSY_ID
-    client_secret: opts.ARTSY_SECRET
-    grant_type: 'credentials'
-    email: username
-    password: password
-  ).end onAccessToken(req, done)
+  request
+    .post("#{opts.ARTSY_URL}/oauth2/access_token")
+    .set('User-Agent': req.get 'user-agent')
+    .query(
+      client_id: opts.ARTSY_ID
+      client_secret: opts.ARTSY_SECRET
+      grant_type: 'credentials'
+      email: username
+      password: password
+    ).end onAccessToken(req, done)
 
 @linkedin = (req, token, tokenSecret, profile, done) ->
   req.socialProfileEmail = profile?.emails?[0]?.value
   # Link Linkedin account
   if req.user
-    request.post(
-      "#{opts.ARTSY_URL}/api/v1/me/authentications/linkedin"
-    ).send(
-      oauth_token: token
-      oauth_token_secret: tokenSecret
-      access_token: req.user.get 'accessToken'
-    ).end (err, res) -> done err, req.user
+    request
+      .post("#{opts.ARTSY_URL}/api/v1/me/authentications/linkedin")
+      .set('User-Agent': req.get 'user-agent')
+      .send(
+        oauth_token: token
+        oauth_token_secret: tokenSecret
+        access_token: req.user.get 'accessToken'
+      ).end (err, res) -> done err, req.user
   # Login with Linkedin account
   else
-    request.post("#{opts.ARTSY_URL}/oauth2/access_token").query(
-      client_id: opts.ARTSY_ID
-      client_secret: opts.ARTSY_SECRET
-      grant_type: 'oauth_token'
-      oauth_token: token
-      oauth_token_secret: tokenSecret
-      oauth_provider: 'linkedin'
-    ).end onAccessToken(req, done,
-      oauth_token: token
-      oauth_token_secret: tokenSecret
-      provider: 'linkedin'
-    )
+    request
+      .post("#{opts.ARTSY_URL}/oauth2/access_token")
+      .set('User-Agent': req.get 'user-agent')
+      .query(
+        client_id: opts.ARTSY_ID
+        client_secret: opts.ARTSY_SECRET
+        grant_type: 'oauth_token'
+        oauth_token: token
+        oauth_token_secret: tokenSecret
+        oauth_provider: 'linkedin'
+      ).end onAccessToken(req, done,
+        oauth_token: token
+        oauth_token_secret: tokenSecret
+        provider: 'linkedin'
+      )
 
 @facebook = (req, token, refreshToken, profile, done) ->
   req.socialProfileEmail = profile?.emails?[0]?.value
   # req.socialProfileEmail = profile
   # Link Facebook account
   if req.user
-    request.post(
-      "#{opts.ARTSY_URL}/api/v1/me/authentications/facebook"
-    ).send(
-      oauth_token: token
-      access_token: req.user.get 'accessToken'
-    ).end (err, res) -> done err, req.user
+    request
+      .post("#{opts.ARTSY_URL}/api/v1/me/authentications/facebook")
+      .set('User-Agent': req.get 'user-agent')
+      .send(
+        oauth_token: token
+        access_token: req.user.get 'accessToken'
+      ).end (err, res) -> done err, req.user
   # Login or signup with Facebook
   else
-    request.post("#{opts.ARTSY_URL}/oauth2/access_token").query(
-      client_id: opts.ARTSY_ID
-      client_secret: opts.ARTSY_SECRET
-      grant_type: 'oauth_token'
-      oauth_token: token
-      oauth_provider: 'facebook'
-    ).end onAccessToken(req, done,
-      oauth_token: token
-      provider: 'facebook'
-      name: profile?.displayName
-    )
+    request
+      .post("#{opts.ARTSY_URL}/oauth2/access_token")
+      .set('User-Agent': req.get 'user-agent')
+      .query(
+        client_id: opts.ARTSY_ID
+        client_secret: opts.ARTSY_SECRET
+        grant_type: 'oauth_token'
+        oauth_token: token
+        oauth_provider: 'facebook'
+      ).end onAccessToken(req, done,
+        oauth_token: token
+        provider: 'facebook'
+        name: profile?.displayName
+      )
 
 @twitter = (req, token, tokenSecret, profile, done) ->
   # Link Twitter account
   if req.user
-    request.post(
-      "#{opts.ARTSY_URL}/api/v1/me/authentications/twitter"
-    ).send(
-      oauth_token: token
-      oauth_token_secret: tokenSecret
-      access_token: req.user.get 'accessToken'
-    ).end (err, res) -> done err, req.user
+    request
+      .post("#{opts.ARTSY_URL}/api/v1/me/authentications/twitter")
+      .set('User-Agent': req.get 'user-agent')
+      .send(
+        oauth_token: token
+        oauth_token_secret: tokenSecret
+        access_token: req.user.get 'accessToken'
+      ).end (err, res) -> done err, req.user
   # Login or signup with Twitter
   else
-    request.post("#{opts.ARTSY_URL}/oauth2/access_token").query(
-      client_id: opts.ARTSY_ID
-      client_secret: opts.ARTSY_SECRET
-      grant_type: 'oauth_token'
-      oauth_token: token
-      oauth_token_secret: tokenSecret
-      oauth_provider: 'twitter'
-    ).end onAccessToken(req, done,
-      oauth_token: token
-      oauth_token_secret: tokenSecret
-      provider: 'twitter'
-      email: opts.twitterSignupTempEmail(token, tokenSecret, profile)
-      name: profile?.displayName
-    )
+    request
+      .post("#{opts.ARTSY_URL}/oauth2/access_token")
+      .set('User-Agent': req.get 'user-agent')
+      .query(
+        client_id: opts.ARTSY_ID
+        client_secret: opts.ARTSY_SECRET
+        grant_type: 'oauth_token'
+        oauth_token: token
+        oauth_token_secret: tokenSecret
+        oauth_provider: 'twitter'
+      ).end onAccessToken(req, done,
+        oauth_token: token
+        oauth_token_secret: tokenSecret
+        provider: 'twitter'
+        email: opts.twitterSignupTempEmail(token, tokenSecret, profile)
+        name: profile?.displayName
+      )
 
 onAccessToken = (req, done, params) -> (err, res) ->
   # Treat bad responses from Gravity as errors and get the most relavent
@@ -124,6 +139,7 @@ onAccessToken = (req, done, params) -> (err, res) ->
         return done err if err
         request
           .post("#{opts.ARTSY_URL}/oauth2/access_token")
+          .set('User-Agent': req.get 'user-agent')
           .query(_.extend params,
             client_id: opts.ARTSY_ID
             client_secret: opts.ARTSY_SECRET

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artsy-passport",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Wires up the common auth handlers for Artsy's [Ezel](ezeljs.com)-based apps using [passport](http://passportjs.org/).",
   "keywords": [
     "artsy",
@@ -24,7 +24,7 @@
     "node": ">= 0.10.x"
   },
   "scripts": {
-    "test": "mocha --recursive",
+    "test": "mocha test/app && mocha test/passport",
     "compile": "browserify -t coffeeify example/client.coffee > example/public/client.js",
     "example": "sleep 3 && open http://local.artsy.net:4000 & npm run compile && coffee example/index.coffee"
   },
@@ -33,6 +33,7 @@
     "async": "^1.5.0",
     "coffee-script": "^1.9.2",
     "csurf": "^1.8.3",
+    "dotenv": "^4.0.0",
     "express": "^4.12.3",
     "mailcheck": "^1.1.1",
     "passport": "^0.2.1",

--- a/test/app/lifecycle.coffee
+++ b/test/app/lifecycle.coffee
@@ -5,14 +5,14 @@ lifecycle = rewire '../../lib/app/lifecycle'
 describe 'lifecycle', ->
 
   beforeEach ->
-    @req = { body: {}, params: {}, query: {}, session: {} }
+    @req = { body: {}, params: {}, query: {}, session: {}, get: sinon.stub() }
     @res = { redirect: sinon.stub(), send: sinon.stub() }
     @next = sinon.stub()
     @passport = {}
     @passport.authenticate = sinon.stub()
     @passport.authenticate.returns (req, res, next) => next()
     @request = sinon.stub().returns @request
-    for method in ['get', 'end', 'set', 'post']
+    for method in ['get', 'end', 'set', 'post', 'send']
       @request[method] = sinon.stub().returns @request
     lifecycle.__set__ 'request', @request
     lifecycle.__set__ 'passport', @passport
@@ -70,6 +70,11 @@ describe 'lifecycle', ->
     it 'suggests an email if its invalid and redirects back to the signup page'
 
     it 'sends 500s as json for xhr requests'
+
+    it 'passes the user agent through signup', ->
+      @req.get.returns 'foo-agent'
+      lifecycle.onLocalSignup @req, @res, @next
+      @request.set.args[0][0]['User-Agent'].should.equal 'foo-agent'
 
   describe '#beforeSocialAuth', ->
 

--- a/test/passport/callbacks.coffee
+++ b/test/passport/callbacks.coffee
@@ -6,7 +6,7 @@ cbs = rewire '../../lib/passport/callbacks'
 describe 'passport callbacks', ->
 
   beforeEach ->
-    @req = {}
+    @req = get: sinon.stub()
     @request = {}
     @request.get = sinon.stub().returns @request
     @request.query = sinon.stub().returns @request
@@ -56,19 +56,15 @@ describe 'passport callbacks', ->
     res = { body: { access_token: 'access-token' }, status: 200 }
     @request.end.args[0][0](null, res)
 
-  it 'signs up a user via twitter', (done) ->
+  it 'denies twitter signup', (done) ->
     cb = (err, user) ->
-      user.get('accessToken').should.equal 'access-token'
+      err.message.should.containEql 'please sign up'
       done()
     cbs.twitter @req, 'foo-token', 'token-secret', { displayName: 'Craig' }, cb
-    @request.post.args[0][0].should
-      .equal 'http://apiz.artsy.net/oauth2/access_token'
     res = { body: { error_description: 'no account linked' }, status: 403 }
     @request.end.args[0][0](null, res)
-    @request.post.args[1][0].should.equal 'http://apiz.artsy.net/api/v1/user'
-    body = @request.send.args[0][0]
-    body.email.should.equal 'foo-token@artsy.tmp'
-    body.name.should.equal 'Craig'
-    @request.end.args[1][0]()
-    res = { body: { access_token: 'access-token' }, status: 200 }
-    @request.end.args[0][0](null, res)
+
+  it 'passes the user agent through login', ->
+    @req.get.returns 'chrome-foo'
+    cbs.local @req, 'craig', 'foo'
+    @request.set.args[0][0].should.containEql 'User-Agent': 'chrome-foo'


### PR DESCRIPTION
Gravity pulls out the user agent header to API requests and persists it to [fields on its user model](https://github.com/artsy/gravity/blob/master/app/models/domain/user.rb#L64). This worked well when Artsy was one glorious Backbone monolith that made all its requests client-side and the browser sent that for free. However, now that we send a lot of things server-side, including access token/account creation API requests, we don't get that for free anymore and many users have a `node-superagent-blah-blah` set as that field. The analytics team uses these Gravity-level fields often so we can be helpful and have the server using Artsy Passport to pass the user agent through these requests. 