### PR TITLE
@craigspaeth => Track logins with Segment

### DIFF
--- a/lib/app/analytics.coffee
+++ b/lib/app/analytics.coffee
@@ -29,3 +29,11 @@ Analytics = require 'analytics-node'
       signup_service: service
       user_id: req.user.get 'id'
   next()
+
+@trackLogin = (req, res, next) ->
+  return next() unless opts.SEGMENT_WRITE_KEY
+  analytics = new Analytics opts.SEGMENT_WRITE_KEY
+  analytics.track
+    event: 'Successfully logged in'
+    userId: req.user.get 'id'
+  next()

--- a/lib/app/index.coffee
+++ b/lib/app/index.coffee
@@ -21,7 +21,7 @@ twitterLastStep = require './twitter_last_step'
   onError,
   ssoAndRedirectBack
 } = require './lifecycle'
-{ setCampaign, trackSignup } = require './analytics'
+{ setCampaign, trackSignup, trackLogin } = require './analytics'
 { denyBadLogoutLinks, logout } = require './logout'
 { headerLogin, trustTokenLogin } = require './token_login'
 addLocals = require './locals'
@@ -36,6 +36,7 @@ module.exports = ->
   app.post opts.loginPagePath,
     csrf(cookie: true),
     onLocalLogin,
+    trackLogin,
     ssoAndRedirectBack
   app.post opts.signupPagePath,
     setCampaign,

--- a/test/app/analytics.coffee
+++ b/test/app/analytics.coffee
@@ -19,6 +19,11 @@ describe 'analytics', ->
     analytics.trackSignup('email') @req, @res, @next
     @analytics.track.args[0][0].properties.signup_service.should.equal 'email'
 
+  it 'tracks login', ->
+    analytics.trackLogin @req, @res, @next
+    @analytics.track.args[0][0].event.should.equal 'Successfully logged in'
+    @analytics.track.args[0][0].userId.should.equal 'foo'
+
   it 'passes along modal_id and acquisition_initiative submitted fields', ->
     @req.body.modal_id = 'foo'
     @req.body.acquisition_initiative = 'bar'


### PR DESCRIPTION
We'd like to instrument login tracking in the loyalty app, but realized that we could maybe just consolidate login tracking within `artsy-passport` (similarly to the sign up tracking going on).

In Force/Micro-g, we basically just do: https://github.com/artsy/force/blob/4348d1d08f8036d9aa76d03dfedd2c7887d05fd8/desktop/analytics/account_creation.js#L75

So, this just moves that (along with the user id) here. Then, we'd release a new version of this lib, and update Force to use it as well as removing those calls from Force.

What do you think? 