### PR TITLE
Render random social auth errors on the login screen

### DIFF
--- a/lib/app/lifecycle.coffee
+++ b/lib/app/lifecycle.coffee
@@ -108,7 +108,8 @@ crypto = require 'crypto'
       msg = "Your IP address was blocked by Facebook."
       res.redirect opts.loginPagePath + '?error=' + msg
     else if err?
-      next err
+      msg = err.message or err.toString?()
+      res.redirect opts.loginPagePath + '?error=' + msg
     else if linkingAccount
       res.redirect opts.settingsPagePath
     else if req.artsyPassportSignedUp and provider is 'twitter'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artsy-passport",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Wires up the common auth handlers for Artsy's [Ezel](ezeljs.com)-based apps using [passport](http://passportjs.org/).",
   "keywords": [
     "artsy",

--- a/test/app/lifecycle.coffee
+++ b/test/app/lifecycle.coffee
@@ -125,6 +125,13 @@ describe 'lifecycle', ->
       @res.redirect.args[0][0]
         .should.equal '/login?error=Your IP address was blocked by Facebook.'
 
+    it 'passes random errors to be rendered on the login screen', ->
+      @passport.authenticate.returns (req, res, next) ->
+        next new Error 'Twitter did not like you'
+      lifecycle.afterSocialAuth('twitter')(@req, @res, @next)
+      @res.redirect.args[0][0]
+        .should.equal '/login?error=Twitter did not like you'
+
     context 'with an error', ->
 
       it 'redirects back to the login page and explains the account ' +


### PR DESCRIPTION
There's two other random social auth errors reported in Sentry and I think we should go ahead and surface those to the user on the login screen instead of landing them on our generic error handler page which gets reported as errors to Sentry.

e.g.

![image](https://cloud.githubusercontent.com/assets/555859/25286463/d452ce74-268b-11e7-8c65-fc3a087f1326.png)
 