### PR TITLE
@mzikherman: Pass user agents through Facebook signups

### DIFF
--- a/lib/passport/callbacks.coffee
+++ b/lib/passport/callbacks.coffee
@@ -134,6 +134,7 @@ onAccessToken = (req, done, params) -> (err, res) ->
     request
       .post(opts.ARTSY_URL + '/api/v1/user')
       .send(params)
+      .set('User-Agent': req.get 'user-agent')
       .set('X-Xapp-Token': artsyXapp.token)
       .end (err) ->
         return done err if err

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artsy-passport",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Wires up the common auth handlers for Artsy's [Ezel](ezeljs.com)-based apps using [passport](http://passportjs.org/).",
   "keywords": [
     "artsy",

--- a/test/passport/callbacks.coffee
+++ b/test/passport/callbacks.coffee
@@ -68,3 +68,10 @@ describe 'passport callbacks', ->
     @req.get.returns 'chrome-foo'
     cbs.local @req, 'craig', 'foo'
     @request.set.args[0][0].should.containEql 'User-Agent': 'chrome-foo'
+
+  it 'passes the user agent through facebook signup', ->
+    @req.get.returns 'foo-bar-baz-ua'
+    cbs.facebook @req, 'foo-token', 'token-secret', { displayName: 'Craig' }
+    res = { body: { error_description: 'no account linked' }, status: 403 }
+    @request.end.args[0][0](null, res)
+    @request.set.args[1][0]['User-Agent'].should.equal 'foo-bar-baz-ua'


### PR DESCRIPTION
Solves https://github.com/artsy/force/issues/1390

I missed a spot when I [tried to pass user agent through our Gravity calls](https://github.com/artsy/artsy-passport/pull/99)