### PR TITLE
@orta => Propagate referer when signing up via email/password

### DIFF
--- a/lib/app/lifecycle.coffee
+++ b/lib/app/lifecycle.coffee
@@ -35,7 +35,7 @@ crypto = require 'crypto'
   req.artsyPassportSignedUp = true
   request
     .post(opts.ARTSY_URL + '/api/v1/user')
-    .set('X-Xapp-Token': artsyXapp.token, 'User-Agent': req.get 'user-agent')
+    .set('X-Xapp-Token': artsyXapp.token, 'User-Agent': req.get 'user-agent', 'Referer': req.get 'referer')
     .send(
       name: req.body.name
       email: req.body.email


### PR DESCRIPTION
Paired with @erikdstock , we made this change in Force's local `node_modules/` and confirmed it works as expected.

We have some Gravity changes that will be using this value.

Question: are you the right person to help us publish this? It seems like you're the only collaborator on https://www.npmjs.com/package/artsy-passport that is still at the company 🙂 