### PR TITLE
@mzikherman => pass signup_intent to gravity user account creation

### DIFF
--- a/lib/app/lifecycle.coffee
+++ b/lib/app/lifecycle.coffee
@@ -61,7 +61,7 @@ crypto = require 'crypto'
 @beforeSocialAuth = (provider) -> (req, res, next) ->
   req.session.redirectTo = req.query['redirect-to']
   req.session.skipOnboarding = req.query['skip-onboarding']
-  req.query['signup-intent'] && req.session.signupIntent = req.query['signup-intent']
+  req.session.signupIntent = req.query['signup-intent'] if req.query['signup-intent']
   options = {}
   options.scope = switch provider
     when 'linkedin' then ['r_basicprofile', 'r_emailaddress']

--- a/lib/app/lifecycle.coffee
+++ b/lib/app/lifecycle.coffee
@@ -40,6 +40,7 @@ crypto = require 'crypto'
       name: req.body.name
       email: req.body.email
       password: req.body.password
+      sign_up_intent: req.body.signupIntent
     ).end (err, sres) ->
       if err and err.message is 'Email is invalid.'
         suggestion = Mailcheck.run(email: req.body.email)?.full
@@ -60,6 +61,7 @@ crypto = require 'crypto'
 @beforeSocialAuth = (provider) -> (req, res, next) ->
   req.session.redirectTo = req.query['redirect-to']
   req.session.skipOnboarding = req.query['skip-onboarding']
+  req.query['signup-intent'] && req.session.signupIntent = req.query['signup-intent']
   options = {}
   options.scope = switch provider
     when 'linkedin' then ['r_basicprofile', 'r_emailaddress']

--- a/lib/passport/callbacks.coffee
+++ b/lib/passport/callbacks.coffee
@@ -130,6 +130,7 @@ onAccessToken = (req, done, params) -> (err, res) ->
   # /user API. Then attempt to fetch the access token again from Gravity and
   # recur back into this onAcccessToken callback.
   else if msg.match('no account linked')?
+    if (req?.session?.signupIntent && params?) then params.signup_intent = req.session.signupIntent
     req.artsyPassportSignedUp = true
     request
       .post(opts.ARTSY_URL + '/api/v1/user')

--- a/lib/passport/callbacks.coffee
+++ b/lib/passport/callbacks.coffee
@@ -130,7 +130,7 @@ onAccessToken = (req, done, params) -> (err, res) ->
   # /user API. Then attempt to fetch the access token again from Gravity and
   # recur back into this onAcccessToken callback.
   else if msg.match('no account linked')?
-    if (req?.session?.signupIntent && params?) then params.signup_intent = req.session.signupIntent
+    if (req?.session?.signupIntent && params?) then params.sign_up_intent = req.session.signupIntent
     req.artsyPassportSignedUp = true
     request
       .post(opts.ARTSY_URL + '/api/v1/user')


### PR DESCRIPTION
This PR updates artsy-passport to add a signup_intent parameter to gravity requests for new account creation, drawing it from either
- the `signupIntent` key for local account creation or 
- using the query string key `signup-intent` + session storage for social/facebook oauth account creation.

I'm not 💯 that I hit every note correctly here.