### PR TITLE
@mzikherman => create segment key for server events

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ app.use artsyPassport
   ARTSY_SECRET: # Artsy client secret
   ARTSY_URL: # SSL Artsy url e.g. https://artsy.net
   APP_URL: # Url pointing back to your app e.g. http://flare.artsy.net
-  SEGMENT_WRITE_KEY: # Segment write key to track signup
+  SEGMENT_WRITE_KEY_SERVER: # Segment write key to track signup
 
   # Defaults you probably don't need to touch
   # -----------------------------------------

--- a/lib/app/analytics.coffee
+++ b/lib/app/analytics.coffee
@@ -2,7 +2,7 @@ opts = require '../options'
 Analytics = require 'analytics-node'
 
 @setCampaign = (req, res, next) ->
-  return next() unless opts.SEGMENT_WRITE_KEY
+  return next() unless opts.SEGMENT_WRITE_KEY_SERVER
   req.session.modalId = (
     req.body.modal_id or
     req.query.modal_id
@@ -18,8 +18,8 @@ Analytics = require 'analytics-node'
   acquisitionInitiative = req.session.acquisitionInitiative
   delete req.session.acquisitionInitiative
   delete req.session.modalId
-  return next() unless opts.SEGMENT_WRITE_KEY
-  analytics = new Analytics opts.SEGMENT_WRITE_KEY
+  return next() unless opts.SEGMENT_WRITE_KEY_SERVER
+  analytics = new Analytics opts.SEGMENT_WRITE_KEY_SERVER
   analytics.track
     event: 'Created account'
     userId: req.user.get 'id'
@@ -31,8 +31,8 @@ Analytics = require 'analytics-node'
   next()
 
 @trackLogin = (req, res, next) ->
-  return next() unless opts.SEGMENT_WRITE_KEY
-  analytics = new Analytics opts.SEGMENT_WRITE_KEY
+  return next() unless opts.SEGMENT_WRITE_KEY_SERVER
+  analytics = new Analytics opts.SEGMENT_WRITE_KEY_SERVER
   analytics.track
     event: 'Successfully logged in'
     userId: req.user.get 'id'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/passport",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Wires up the common auth handlers for Artsy's [Ezel](ezeljs.com)-based apps using [passport](http://passportjs.org/).",
   "keywords": [
     "artsy",


### PR DESCRIPTION
cc @anipetrov 
This PR updates artsy-passport's server-side analytics tracking to use a new segment write key (inherited from force, generally) for server-side events. I am wondering if we should adjust this to massage the new `_SERVER` key name back into a regular `SEGMENT_WRITE_KEY` since passport doesn't really care- but maybe that is overthinking it.



_aside:_ I think this change should do it, but was unable to verify due to some troubles with yarn linking this to force - essentially this package's npm package `artsy-xapp` does not find the `.token` that should be set in force's `artsy-xapp` on start.