### PR TITLE
save accepted_terms_of_service & receive_emails at signup

### DIFF
--- a/lib/app/lifecycle.coffee
+++ b/lib/app/lifecycle.coffee
@@ -41,6 +41,8 @@ crypto = require 'crypto'
       email: req.body.email
       password: req.body.password
       sign_up_intent: req.body.signupIntent
+      accepted_terms_of_service: req.body.accepted_terms_of_service,
+      receive_emails: req.body.receive_emails,
     ).end (err, sres) ->
       if err and err.message is 'Email is invalid.'
         suggestion = Mailcheck.run(email: req.body.email)?.full
@@ -61,7 +63,9 @@ crypto = require 'crypto'
 @beforeSocialAuth = (provider) -> (req, res, next) ->
   req.session.redirectTo = req.query['redirect-to']
   req.session.skipOnboarding = req.query['skip-onboarding']
-  req.session.signupIntent = req.query['signup-intent'] if req.query['signup-intent']
+  req.session.sign_up_intent = req.query['signup-intent']
+  req.session.accepted_terms_of_service = req.query['accepted_terms_of_service']
+  req.session.receive_emails = req.query['receive_emails']
   options = {}
   options.scope = switch provider
     when 'linkedin' then ['r_basicprofile', 'r_emailaddress']

--- a/lib/app/lifecycle.coffee
+++ b/lib/app/lifecycle.coffee
@@ -64,8 +64,8 @@ crypto = require 'crypto'
   req.session.redirectTo = req.query['redirect-to']
   req.session.skipOnboarding = req.query['skip-onboarding']
   req.session.sign_up_intent = req.query['signup-intent']
-  req.session.accepted_terms_of_service = req.query['accepted_terms_of_service']
-  req.session.receive_emails = req.query['receive_emails']
+  req.session.accepted_terms_of_service = req.query['accepted-terms-of-service']
+  req.session.receive_emails = req.query['receive-emails']
   options = {}
   options.scope = switch provider
     when 'linkedin' then ['r_basicprofile', 'r_emailaddress']

--- a/lib/passport/callbacks.coffee
+++ b/lib/passport/callbacks.coffee
@@ -130,7 +130,10 @@ onAccessToken = (req, done, params) -> (err, res) ->
   # /user API. Then attempt to fetch the access token again from Gravity and
   # recur back into this onAcccessToken callback.
   else if msg.match('no account linked')?
-    if (req?.session?.signupIntent && params?) then params.sign_up_intent = req.session.signupIntent
+    if (req?.session? && params?)
+      { sign_up_intent, receive_emails, accepted_terms_of_service } = req.session
+      Object.assign(params, { sign_up_intent, receive_emails, accepted_terms_of_service } )
+
     req.artsyPassportSignedUp = true
     request
       .post(opts.ARTSY_URL + '/api/v1/user')

--- a/lib/passport/callbacks.coffee
+++ b/lib/passport/callbacks.coffee
@@ -132,7 +132,7 @@ onAccessToken = (req, done, params) -> (err, res) ->
   else if msg.match('no account linked')?
     if (req?.session? && params?)
       { sign_up_intent, receive_emails, accepted_terms_of_service } = req.session
-      Object.assign(params, { sign_up_intent, receive_emails, accepted_terms_of_service } )
+      params = { ...params, ...{ sign_up_intent, receive_emails, accepted_terms_of_service } }
 
     req.artsyPassportSignedUp = true
     request

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/passport",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Wires up the common auth handlers for Artsy's [Ezel](ezeljs.com)-based apps using [passport](http://passportjs.org/).",
   "keywords": [
     "artsy",


### PR DESCRIPTION
This updates artsy-passport to save new fields for gdpr compliance on account creation. It should be relatively straightforward.

I changed this to a WIP while I figure out how I'm going to approach sending these params during social login.
Related: artsy/force#2244