### PR TITLE
@erikdstock: uses extend in favor the spread syntax

### DIFF
--- a/lib/passport/callbacks.coffee
+++ b/lib/passport/callbacks.coffee
@@ -132,7 +132,7 @@ onAccessToken = (req, done, params) -> (err, res) ->
   else if msg.match('no account linked')?
     if (req?.session? && params?)
       { sign_up_intent, receive_emails, accepted_terms_of_service } = req.session
-      params = { ...params, ...{ sign_up_intent, receive_emails, accepted_terms_of_service } }
+      _.extend(params, { sign_up_intent, receive_emails, accepted_terms_of_service })
 
     req.artsyPassportSignedUp = true
     request


### PR DESCRIPTION
Uses the `extend` in favor of the spread (`...`) syntax because the version of coffeescript we are using doesn't support the spread.