### PR TITLE
align gdpr property names

### DIFF
--- a/lib/app/lifecycle.coffee
+++ b/lib/app/lifecycle.coffee
@@ -64,8 +64,9 @@ crypto = require 'crypto'
   req.session.redirectTo = req.query['redirect-to']
   req.session.skipOnboarding = req.query['skip-onboarding']
   req.session.sign_up_intent = req.query['signup-intent']
-  req.session.accepted_terms_of_service = req.query['accepted-terms-of-service']
-  req.session.receive_emails = req.query['receive-emails']
+  # accepted_terms_of_service and receive_emails use underscores
+  req.session.accepted_terms_of_service = req.query['accepted_terms_of_service']
+  req.session.receive_emails = req.query['receive_emails']
   options = {}
   options.scope = switch provider
     when 'linkedin' then ['r_basicprofile', 'r_emailaddress']


### PR DESCRIPTION
cc @mzikherman - A helper in our backbone views was used to account for the AB test + presence of 2 checkboxes, and so we needed to make this property name consistent whether in a url or signup POST body.