### PR TITLE
@mzikherman => Use explicit referer instead of on the request

### DIFF
--- a/lib/app/lifecycle.coffee
+++ b/lib/app/lifecycle.coffee
@@ -41,6 +41,7 @@ crypto = require 'crypto'
       email: req.body.email
       password: req.body.password
       sign_up_intent: req.body.signupIntent
+      sign_up_referer: req.body.signupReferer
       accepted_terms_of_service: req.body.accepted_terms_of_service,
       receive_emails: req.body.receive_emails,
     ).end (err, sres) ->
@@ -64,6 +65,7 @@ crypto = require 'crypto'
   req.session.redirectTo = req.query['redirect-to']
   req.session.skipOnboarding = req.query['skip-onboarding']
   req.session.sign_up_intent = req.query['signup-intent']
+  req.session.sign_up_referer = req.query['signup-referer']
   # accepted_terms_of_service and receive_emails use underscores
   req.session.accepted_terms_of_service = req.query['accepted_terms_of_service']
   req.session.receive_emails = req.query['receive_emails']

--- a/lib/passport/callbacks.coffee
+++ b/lib/passport/callbacks.coffee
@@ -53,7 +53,6 @@ artsyXapp = require 'artsy-xapp'
 
 @facebook = (req, token, refreshToken, profile, done) ->
   req.socialProfileEmail = profile?.emails?[0]?.value
-  # req.socialProfileEmail = profile
   # Link Facebook account
   if req.user
     request
@@ -131,8 +130,8 @@ onAccessToken = (req, done, params) -> (err, res) ->
   # recur back into this onAcccessToken callback.
   else if msg.match('no account linked')?
     if (req?.session? && params?)
-      { sign_up_intent, receive_emails, accepted_terms_of_service } = req.session
-      _.extend(params, { sign_up_intent, receive_emails, accepted_terms_of_service })
+      { sign_up_intent, sign_up_referer, receive_emails, accepted_terms_of_service } = req.session
+      _.extend(params, { sign_up_intent, sign_up_referer, receive_emails, accepted_terms_of_service })
 
     req.artsyPassportSignedUp = true
     request

--- a/package.json
+++ b/package.json
@@ -1,13 +1,9 @@
 {
   "name": "@artsy/passport",
-  "version": "1.0.8",
-  "description": "Wires up the common auth handlers for Artsy's [Ezel](ezeljs.com)-based apps using [passport](http://passportjs.org/).",
-  "keywords": [
-    "artsy",
-    "passport",
-    "auth",
-    "authentication"
-  ],
+  "version": "1.0.9",
+  "description":
+    "Wires up the common auth handlers for Artsy's [Ezel](ezeljs.com)-based apps using [passport](http://passportjs.org/).",
+  "keywords": ["artsy", "passport", "auth", "authentication"],
   "author": {
     "name": "Craig Spaeth",
     "email": "craigspaeth@gmail.com",
@@ -25,10 +21,14 @@
   },
   "main": "dist/index.js",
   "scripts": {
-    "test": "mkdir -p dist/app && cp lib/app/sanitize_redirect.js dist/app && mocha test/app && mocha test/passport",
-    "compile": "coffee -c -o dist lib; cp lib/app/sanitize_redirect.js dist/app",
-    "compile-example": "browserify -t coffeeify example/client.coffee > example/public/client.js",
-    "example": "sleep 3 && open http://local.artsy.net:4000 & npm run compile && coffee example/index.coffee"
+    "test":
+      "mkdir -p dist/app && cp lib/app/sanitize_redirect.js dist/app && mocha test/app && mocha test/passport",
+    "compile":
+      "coffee -c -o dist lib; cp lib/app/sanitize_redirect.js dist/app",
+    "compile-example":
+      "browserify -t coffeeify example/client.coffee > example/public/client.js",
+    "example":
+      "sleep 3 && open http://local.artsy.net:4000 & npm run compile && coffee example/index.coffee"
   },
   "dependencies": {
     "analytics-node": "^2.1.0",


### PR DESCRIPTION
Mimics `sign_up_intent` to pass in the referer directly instead of getting it from req. I kept the places where we set a Referer like [here](https://github.com/artsy/artsy-passport/blob/master/lib/app/lifecycle.coffee#L38) to ensure we can use both up until we flip the switch in Gravity. 