### PR TITLE
@mzikherman => Bump passport version and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,6 @@ The tests are a combination of integration and middleware unit tests. To run the
 ## Publishing to npm
 
 ```
-npm run compile
-npm publish
+yarn compile
+yarn publish
 ```

--- a/README.md
+++ b/README.md
@@ -233,3 +233,10 @@ module.exports =
 Then you can check the example by running `npm run example` and opening [localhost:4000](http://localhost:4000).
 
 The tests are a combination of integration and middleware unit tests. To run the whole suite use `npm test`.
+
+## Publishing to npm
+
+```
+npm run compile
+npm publish
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/passport",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description":
     "Wires up the common auth handlers for Artsy's [Ezel](ezeljs.com)-based apps using [passport](http://passportjs.org/).",
   "keywords": ["artsy", "passport", "auth", "authentication"],


### PR DESCRIPTION
I accidentally published 1.0.9 to npm without compiling first -- didn't realize this was part of the step! This bumps the version again so we can actually use it and adds some documentation around how to publish. 