### PR TITLE
Add recaptcha_token to allowed userKeys

### DIFF
--- a/lib/options.coffee
+++ b/lib/options.coffee
@@ -24,5 +24,6 @@ module.exports =
   logoutPath: '/users/sign_out'
   userKeys: [
     'id', 'type', 'name', 'email', 'phone', 'lab_features',
-    'default_profile_id', 'has_partner_access', 'collector_level'
+    'default_profile_id', 'has_partner_access', 'collector_level',
+    'recaptcha_token'
   ]


### PR DESCRIPTION
Adds field `recaptcha_token` to accepted params for signup. This enables us to pass the field to Gravity for validation.

Have tested this linked in Force and signups complete without errors when sending this data with requests.