### PR TITLE
WIP: Return redirect url on xhr requests

### DIFF
--- a/lib/app/lifecycle.coffee
+++ b/lib/app/lifecycle.coffee
@@ -123,7 +123,7 @@ crypto = require 'crypto'
   parsed = parse redirectBack req
   parsed = parse resolve opts.APP_URL, parsed.path unless parsed.hostname
   domain = parsed.hostname?.split('.').slice(1).join('.')
-  return redirectBack(req, res) if domain isnt 'artsy.net'
+  # return redirectBack(req, res) if domain isnt 'artsy.net'
   request
     .post "#{opts.ARTSY_URL}/api/v1/me/trust_token"
     .set { 'X-Access-Token': req.user.get 'accessToken' }

--- a/lib/app/lifecycle.coffee
+++ b/lib/app/lifecycle.coffee
@@ -120,7 +120,7 @@ crypto = require 'crypto'
 
 @ssoAndRedirectBack = (req, res, next) ->
   urlToRedirectTo = parse redirectBack req
-  urlToRedirectTo = parse resolve "https://staging.artsy.net", urlToRedirectTo.path unless urlToRedirectTo.hostname
+  urlToRedirectTo = parse resolve opts.APP_URL, urlToRedirectTo.path unless urlToRedirectTo.hostname
   domain = urlToRedirectTo.hostname?.split('.').slice(1).join('.')
   # return redirectBack(req, res) if domain isnt 'artsy.net'
   request
@@ -134,6 +134,6 @@ crypto = require 'crypto'
         "&redirect_uri=#{urlToRedirectTo.href}"
 
       if req.xhr?
-        res.send { success: true, redirect_uri: apiAuthWithRedirectUrl, user: req.user.toJSON() }
+        res.send { success: true, api_sign_in_with_redirect: apiAuthWithRedirectUrl, user: req.user.toJSON() }
       else
         res.redirect apiAuthWithRedirectUrl

--- a/lib/app/lifecycle.coffee
+++ b/lib/app/lifecycle.coffee
@@ -121,8 +121,7 @@ crypto = require 'crypto'
 @ssoAndRedirectBack = (req, res, next) ->
   urlToRedirectTo = parse redirectBack req
   urlToRedirectTo = parse resolve opts.APP_URL, urlToRedirectTo.path unless urlToRedirectTo.hostname
-  domain = urlToRedirectTo.hostname?.split('.').slice(1).join('.')
-  # return redirectBack(req, res) if domain isnt 'artsy.net'
+
   request
     .post "#{opts.ARTSY_URL}/api/v1/me/trust_token"
     .set { 'X-Access-Token': req.user.get 'accessToken' }

--- a/lib/app/redirectback.coffee
+++ b/lib/app/redirectback.coffee
@@ -12,6 +12,7 @@ module.exports = (req, res) ->
     req.body['redirect-to'] or
     req.query['redirect-to'] or
     req.params.redirect_uri or
+    req.referrer or
     '/'
   )
   delete req.session.redirectTo

--- a/lib/app/redirectback.coffee
+++ b/lib/app/redirectback.coffee
@@ -12,7 +12,7 @@ module.exports = (req, res) ->
     req.body['redirect-to'] or
     req.query['redirect-to'] or
     req.params.redirect_uri or
-    req.referrer or
+    req.get('Referer') or
     '/'
   )
   delete req.session.redirectTo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/passport",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "description": "Wires up the common auth handlers for Artsy's [Ezel](ezeljs.com)-based apps using [passport](http://passportjs.org/).",
   "keywords": [
     "artsy",

--- a/test/app/lifecycle.coffee
+++ b/test/app/lifecycle.coffee
@@ -204,7 +204,13 @@ describe 'lifecycle', ->
             get: -> 'token'
             toJSON: -> {}
           }
-          @req.referrer = "https://service.artsy.net/auctions"
+          # TODO: this is an incredibly brittle stub – maybe we should be using
+          # something like https://www.npmjs.com/package/sinon-express-mock
+          # instead.
+          @req.get =
+            (key) ->
+              if key == 'Referer'
+                'https://service.artsy.net/auctions'
 
           lifecycle.ssoAndRedirectBack(@req, @res, @next)
           @request.end.args[0][0] null, { body: { trust_token: 'foo-trust-token' } }

--- a/test/app/lifecycle.coffee
+++ b/test/app/lifecycle.coffee
@@ -19,8 +19,8 @@ describe 'lifecycle', ->
     lifecycle.__set__ 'opts', @opts = {
       loginPagePath: '/login'
       afterSignupPagePath: '/personalize'
-      APP_URL: 'https://www.artsy.net'
-      ARTSY_URL: 'https://api.artsy.net'
+      APP_URL: 'https://staging.artsy.net'
+      ARTSY_URL: 'https://stagingapi.artsy.net'
     }
 
   describe '#onLocalLogin', ->
@@ -162,8 +162,14 @@ describe 'lifecycle', ->
 
     it 'passes on for xhrs', ->
       @req.xhr = true
-      @req.user = { toJSON: -> }
-      lifecycle.ssoAndRedirectBack @req, @res, @next
+      @req.user = {
+        get: -> 'token'
+        toJSON: -> {}
+      }
+
+      lifecycle.ssoAndRedirectBack(@req, @res, @next)
+      @request.end.args[0][0] null, { body: { trust_token: 'foo-trust-token' } }
+
       @res.send.args[0][0].success.should.equal true
 
     it 'single signs on to gravity', ->
@@ -173,8 +179,9 @@ describe 'lifecycle', ->
       @request.post.args[0][0].should.containEql 'me/trust_token'
       @request.end.args[0][0] null, { body: { trust_token: 'foo-trust-token' } }
       @res.redirect.args[0][0].should.equal(
-        'https://api.artsy.net/users/sign_in' +
+        'https://stagingapi.artsy.net/users/sign_in' +
         '?trust_token=foo-trust-token' +
-        '&redirect_uri=https://www.artsy.net/artwork/andy-warhol-skull'
+        '&redirect_uri=https://staging.artsy.net/artwork/andy-warhol-skull'
       )
 
+  


### PR DESCRIPTION
## Problem

We don't want to require users to sign in twice when accessing an auction (once for www.artsy.net, another time when accessing live.artsy.net). As such, we want to be able to sign into Gravity when signing into Force. At some point, this behavior worked (https://github.com/artsy/artsy-passport/pull/80), but was broken. We strongly suspect that this broke when we migrated Force's auth to use modals instead of server-side ajax.

To effectively authenticate with Gravity from Force, we need to expose the ability to authenticate with Force **client-side**. This PR does that by leveraging existing Gravity endpoints that perform authentication of `GET`s.

A sibling Force PR leverages the JSON payload now returned from artsy-passport to perform the client side redirect: https://github.com/artsy/force/pull/4349

## Solution 

Include a `api_sign_in_with_redirect` in the JSON response returned when auth'ing to Force over AJAX.

Jira: https://artsyproduct.atlassian.net/browse/AUCT-281

---

TODO:

- [x] Figure out if we need the [short circuit return](https://github.com/artsy/artsy-passport/compare/master...dleve123:return-redirect-url-on-xhr-requests?expand=1#diff-c7d8f6e9781b93e5f26d9a3fbfbf13c0R125) it makes it hard to test locally
  - opted to remove for now: https://github.com/artsy/artsy-passport/pull/133#discussion_r308912136
- [x] Resolve test failures
- [x] Bump minor version