### PR TITLE
@joeyAghion => [Logout] Make sure to clear session explicitly when logging out

### DIFF
--- a/lib/app/logout.coffee
+++ b/lib/app/logout.coffee
@@ -16,6 +16,7 @@ redirectBack = require './redirectback'
 @logout = (req, res, next) ->
   accessToken = req.user?.get('accessToken')
   req.logout()
+  req.session = null
   request
     .del("#{opts.ARTSY_URL}/api/v1/access_token")
     .set('X-Access-Token': accessToken)


### PR DESCRIPTION
Relevant docs:
https://stackoverflow.com/questions/31641884/does-passports-logout-function-remove-the-cookie-if-not-how-does-it-work

I think the sequence of events we see is:
  - you get a cookie for 1 day with an `id`. theres no `user`
  - when you login, there's a `user` there, so we can correctly be auth'ed/unauth'ed
  - when you logout, we clear `user` from that cookie. still correctly auth'ed/unauth'ed
  - but, a stale `id` (maybe other stuff?) exists