### PR TITLE
Switch to passport-local-with-otp strategy to support 2FA

### DIFF
--- a/lib/app/lifecycle.coffee
+++ b/lib/app/lifecycle.coffee
@@ -17,7 +17,7 @@ crypto = require 'crypto'
 
 @onLocalLogin = (req, res, next) ->
   return next() if req.user and not req.xhr
-  passport.authenticate('local') req, res, (err) ->
+  passport.authenticate('local-with-otp') req, res, (err) ->
     if req.xhr
       if err
         res.status(500).send({ success: false, error: err.message })

--- a/lib/passport/callbacks.coffee
+++ b/lib/passport/callbacks.coffee
@@ -22,7 +22,7 @@ resolveProxies = (req) ->
   else
     return ipAddress
 
-@local = (req, username, password, done) ->
+@local = (req, username, password, otp, done) ->
   post = request
     .post("#{opts.ARTSY_URL}/oauth2/access_token")
     .set({ 'User-Agent': req.get 'user-agent' })
@@ -32,6 +32,7 @@ resolveProxies = (req) ->
       grant_type: 'credentials'
       email: username
       password: password
+      otp_attempt: otp
     })
 
   if req?.connection?.remoteAddress?

--- a/lib/passport/index.coffee
+++ b/lib/passport/index.coffee
@@ -5,7 +5,7 @@
 passport = require 'passport'
 FacebookStrategy = require('passport-facebook').Strategy
 AppleStrategy = require('@nicokaiser/passport-apple').Strategy
-LocalStrategy = require('passport-local').Strategy
+LocalWithOtpStrategy = require('@artsy/passport-local-with-otp').Strategy
 callbacks = require './callbacks'
 { serialize, deserialize } = require './serializers'
 opts = require '../options'
@@ -13,9 +13,10 @@ opts = require '../options'
 module.exports = ->
   passport.serializeUser serialize
   passport.deserializeUser deserialize
-  passport.use new LocalStrategy(
+  passport.use new LocalWithOtpStrategy(
     {
       usernameField: 'email'
+      otpField: 'otp_attempt'
       passReqToCallback: true
     },
     callbacks.local

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/passport",
-  "version": "2.0.0",
+  "version": "1.2.0-rc1",
   "description": "Wires up the common auth handlers for Artsy's [Ezel](https://github.com/artsy/ezel)-based apps using [passport](http://passportjs.org/).",
   "keywords": [
     "artsy",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/passport",
-  "version": "1.1.13",
+  "version": "2.0.0",
   "description": "Wires up the common auth handlers for Artsy's [Ezel](https://github.com/artsy/ezel)-based apps using [passport](http://passportjs.org/).",
   "keywords": [
     "artsy",
@@ -32,6 +32,7 @@
     "example": "sleep 3 && open http://local.artsy.net:4000 & npm run compile && coffee example/index.coffee"
   },
   "dependencies": {
+    "@artsy/passport-local-with-otp": "^0.3.0",
     "@nicokaiser/passport-apple": "^0.2.1",
     "analytics-node": "^2.1.0",
     "async": "^1.5.0",
@@ -42,7 +43,6 @@
     "mailcheck": "^1.1.1",
     "passport": "^0.3.0",
     "passport-facebook": "^2.0.0",
-    "passport-local": "^1.0.0",
     "superagent": "^1.2.0",
     "underscore.string": "^3.2.2"
   },

--- a/test/passport/callbacks.coffee
+++ b/test/passport/callbacks.coffee
@@ -22,8 +22,17 @@ describe 'passport callbacks', ->
       CurrentUser: Backbone.Model
     }
 
-  it 'gets a user with an access token email/password', (done) ->
-    cbs.local @req, 'craig', 'foo', (err, user) ->
+  it 'gets a user with an access token email/password/otp', (done) ->
+    cbs.local @req, 'craig', 'foo', '123456', (err, user) ->
+      user.get('accessToken').should.equal 'access-token'
+      done()
+    @request.post.args[0][0].should
+      .equal 'http://apiz.artsy.net/oauth2/access_token'
+    res = { body: { access_token: 'access-token' }, status: 200 }
+    @request.end.args[0][0](null, res)
+
+  it 'gets a user with an access token email/password without otp', (done) ->
+    cbs.local @req, 'craig', 'foo', null, (err, user) ->
       user.get('accessToken').should.equal 'access-token'
       done()
     @request.post.args[0][0].should
@@ -73,4 +82,3 @@ describe 'passport callbacks', ->
     res = { body: { error_description: 'no account linked' }, status: 403 }
     @request.end.args[0][0](null, res)
     @request.set.args[1][0]['User-Agent'].should.equal 'foo-bar-baz-ua'
- 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@artsy/passport-local-with-otp@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@artsy/passport-local-with-otp/-/passport-local-with-otp-0.3.0.tgz#c27bf342ad0cff13378ace9caae7395bec3c46fd"
+  integrity sha512-gzN4InPgDdtNLxmziTk9ZmrMAf41zCGxG0CP8Fm5Q5RxWZxBJt6FkCqfQeBhpihU2L74lvseDxi5LYI8mkdOdQ==
+  dependencies:
+    passport-strategy "1.x.x"
+
 "@nicokaiser/passport-apple@^0.2.1":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@nicokaiser/passport-apple/-/passport-apple-0.2.1.tgz#e224f0b12d7326082c50e376078ec25caabcb12a"
@@ -2041,13 +2048,6 @@ passport-facebook@^2.0.0:
   integrity sha1-w50LUq5NWRYyRaTiGnubYyEwMxE=
   dependencies:
     passport-oauth2 "1.x.x"
-
-passport-local@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/passport-local/-/passport-local-1.0.0.tgz#1fe63268c92e75606626437e3b906662c15ba6ee"
-  integrity sha1-H+YyaMkudWBmJkN+O5BmYsFbpu4=
-  dependencies:
-    passport-strategy "1.x.x"
 
 passport-oauth2@1.x.x:
   version "1.3.0"


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/TRUST-211

This PR changes the Passport strategy used by this library…

- from https://github.com/jaredhanson/passport-local
- to https://github.com/artsy/passport-local-with-otp
  - (our new OTP-compatible fork of `passport-local`)

We increment the major version number of this package (to v2.0.0) because it is a breaking change that will require code changes in Force once it is imported there.

I'm assuming that major version bump will also [prevent auto-merging](https://github.com/artsy/renovate-config/blob/f330e4f8631d00328bedc97710d5a30c1d86f656/lib/config.js#L13-L18) of this change into Force (by Renovate), thus allowing us to adequately QA this via review app before merging manually.