### PR TITLE
Set X-Forwarded-For when signing up and logging in

### DIFF
--- a/lib/app/forwarded_for.coffee
+++ b/lib/app/forwarded_for.coffee
@@ -1,0 +1,16 @@
+ip = require 'ip'
+
+resolveIPv4 = (ipAddress) ->
+  if ip.isV6Format(ipAddress)? and ipAddress.indexOf('::ffff') >= 0
+    return ipAddress.split('::ffff:')[1]
+  return ipAddress
+
+#
+# Set or append to list of X-Forwarded-For IP addresses (adapted from Force)
+#
+module.exports = (req) ->
+  ipAddress = resolveIPv4(req.connection.remoteAddress)
+  if req?.headers?["x-forwarded-for"]?
+    return req.headers["x-forwarded-for"] + "," + ipAddress
+  else
+    return ipAddress

--- a/lib/app/lifecycle.coffee
+++ b/lib/app/lifecycle.coffee
@@ -5,6 +5,7 @@
 
 _ = require 'underscore'
 _s = require 'underscore.string'
+forwardedFor = require './forwarded_for'
 opts = require '../options'
 passport = require 'passport'
 qs = require 'querystring'
@@ -37,6 +38,7 @@ crypto = require 'crypto'
     .post(opts.ARTSY_URL + '/api/v1/user')
     .set({
       'X-Xapp-Token': artsyXapp.token,
+      'X-Forwarded-For': forwardedFor(req),
       'User-Agent': req.get('user-agent'),
       'Referer': req.get('referer')
     })
@@ -130,8 +132,10 @@ crypto = require 'crypto'
   return redirectBack(req, res) if domain isnt 'artsy.net'
   request
     .post "#{opts.ARTSY_URL}/api/v1/me/trust_token"
-    .set { 'X-Access-Token': req.user.get 'accessToken' }
-    .end (err, sres) ->
+    .set({
+      'X-Access-Token': req.user.get 'accessToken',
+      'X-Forwarded-For': forwardedFor(req)
+    }).end (err, sres) ->
       return res.redirect parsed.href if err
       res.redirect "#{opts.ARTSY_URL}/users/sign_in" +
         "?trust_token=#{sres.body.trust_token}" +

--- a/lib/app/logout.coffee
+++ b/lib/app/logout.coffee
@@ -6,6 +6,7 @@ request = require 'superagent'
 opts = require '../options'
 { parse } = require 'url'
 redirectBack = require './redirectback'
+forwardedFor = require './forwarded_for'
 
 @denyBadLogoutLinks = (req, res, next) ->
   if parse(req.get 'Referrer').hostname.match 'artsy.net'
@@ -19,7 +20,7 @@ redirectBack = require './redirectback'
   req.session = null
   request
     .del("#{opts.ARTSY_URL}/api/v1/access_token")
-    .set('X-Access-Token': accessToken)
+    .set('X-Access-Token': accessToken, 'X-Forwarded-For': forwardedFor(req))
     .end (error, response) ->
       if req.xhr
         res.status(200).send msg: 'success'

--- a/lib/app/token_login.coffee
+++ b/lib/app/token_login.coffee
@@ -3,6 +3,7 @@
 # trust_token in the query params.
 #
 
+forwardedFor = require './forwarded_for'
 opts = require '../options'
 qs = require 'querystring'
 request = require 'superagent'
@@ -24,6 +25,7 @@ _  = require 'underscore'
     code: token
   request
     .post "#{opts.ARTSY_URL}/oauth2/access_token"
+    .set('X-Forwarded-For': forwardedFor(req))
     .send settings
     .end (err, response) ->
       return next() if err? or not response.ok

--- a/test/app/lifecycle.coffee
+++ b/test/app/lifecycle.coffee
@@ -5,7 +5,7 @@ lifecycle = rewire '../../lib/app/lifecycle'
 describe 'lifecycle', ->
 
   beforeEach ->
-    @req = { body: {}, params: {}, query: {}, session: {}, get: sinon.stub() }
+    @req = { body: {}, params: {}, query: {}, session: {}, get: sinon.stub(), connection: { remoteAddress: '99.99.99.99' } }
     @res = {
       redirect: sinon.stub(),
       send: sinon.stub(),


### PR DESCRIPTION
This PR copies [the pattern between Force and Metaphysics](https://github.com/artsy/force/blob/e908f2453b7b077b2ec4294e03cbfabf13dde802/src/lib/metaphysics2.coffee) for appending the end user's IP address to a `X-Forwarded-For` header. This is useful when, e.g., end users' browsers POST to `/sign_up` and Force translates that into a POST from its server-side to Gravity's `/api/v1/user` endpoint.

Don't merge this yet because:
* When I run Force with this locally, I get a strange error about a nearby header value (`Invalid value "undefined" for header "X-Xapp-Token"`). Maybe we can look at it? My set-up or config must be wrong.
* Should this use `req.ip` or `req.connection.remoteAddress`? Force uses the former for geocoding, but the latter when setting `X-Forwarded-For` on its requests to Metaphysics.