### PR TITLE
Apple sign in pass token to gravity

### DIFF
--- a/lib/passport/index.coffee
+++ b/lib/passport/index.coffee
@@ -4,7 +4,7 @@
 
 passport = require 'passport'
 FacebookStrategy = require('passport-facebook').Strategy
-AppleStrategy = require('@nicokaiser/passport-apple').Strategy
+AppleStrategy = require('passport-apple')
 LocalWithOtpStrategy = require('@artsy/passport-local-with-otp').Strategy
 callbacks = require './callbacks'
 { serialize, deserialize } = require './serializers'
@@ -35,15 +35,15 @@ module.exports = ->
 
   if opts.APPLE_CLIENT_ID and opts.APPLE_TEAM_ID and
      opts.APPLE_KEY_ID and opts.APPLE_PRIVATE_KEY
-    passport.use 'apple', new AppleStrategy(
+    passport.use(new AppleStrategy(
       {
         clientID: opts.APPLE_CLIENT_ID
         teamID: opts.APPLE_TEAM_ID
         keyID: opts.APPLE_KEY_ID
-        key: opts.APPLE_PRIVATE_KEY
+        privateKeyString: opts.APPLE_PRIVATE_KEY
         passReqToCallback: true
         callbackURL: "#{opts.APP_URL}#{opts.appleCallbackPath}"
         scope: ['name', 'email']
       },
       callbacks.apple
-    )
+    ))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artsy/passport",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Wires up the common auth handlers for Artsy's [Ezel](https://github.com/artsy/ezel)-based apps using [passport](http://passportjs.org/).",
   "keywords": [
     "artsy",
@@ -33,7 +33,6 @@
   },
   "dependencies": {
     "@artsy/passport-local-with-otp": "^0.3.0",
-    "@nicokaiser/passport-apple": "^0.2.1",
     "analytics-node": "^2.1.0",
     "async": "^1.5.0",
     "csurf": "^1.8.3",
@@ -42,6 +41,7 @@
     "ip": "^1.1.5",
     "mailcheck": "^1.1.1",
     "passport": "^0.3.0",
+    "passport-apple": "https://github.com/artsy/passport-apple",
     "passport-facebook": "^2.0.0",
     "superagent": "^1.2.0",
     "underscore.string": "^3.2.2"

--- a/test/passport/callbacks.coffee
+++ b/test/passport/callbacks.coffee
@@ -53,7 +53,8 @@ describe 'passport callbacks', ->
     @request.end.args[0][0](null, res)
 
   it 'gets a user with an access token apple', (done) ->
-    cbs.apple @req, 'foo-token', 'refresh-token', { id: 'some-apple-uid' }, (err, user) ->
+    decodedIdToken = { email: 'some-email@some.com', sub: 'some-apple-uid' }
+    cbs.apple @req, 'id-token', decodedIdToken, 'access_token', 'refresh-token', (err, user) ->
       user.get('accessToken').should.equal 'access-token'
       done()
     @request.post.args[0][0].should

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,16 +9,6 @@
   dependencies:
     passport-strategy "1.x.x"
 
-"@nicokaiser/passport-apple@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@nicokaiser/passport-apple/-/passport-apple-0.2.1.tgz#e224f0b12d7326082c50e376078ec25caabcb12a"
-  integrity sha512-5Spi6fl4KabSHkcjpXQEnd5BnmMptNaDNHndCiGLg2fK9OwLVE6OrgQQZi9mZqmjaPtWyivzV1dSegN+uB3xFQ==
-  dependencies:
-    jsonwebtoken "^8.5.1"
-    oauth "^0.9.15"
-    passport-strategy "^1.0.0"
-    uid2 "0.0.3"
-
 "@segment/loosely-validate-event@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@segment/loosely-validate-event/-/loosely-validate-event-1.1.2.tgz#d77840999e3f7e43e74b3b0d43391c1526f793b8"
@@ -237,6 +227,11 @@ base64-url@1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/base64-url/-/base64-url-1.2.2.tgz#90af26ef8b0b67bc801b05eccf943345649008b3"
   integrity sha1-kK8m74sLZ7yAGwXsz5QzRWSQCLM=
+
+base64url@3.x.x:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/base64url/-/base64url-3.0.1.tgz#6399d572e2bc3f90a9a8b22d5dbb0a32d33f788d"
+  integrity sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==
 
 basic-auth@~2.0.0:
   version "2.0.1"
@@ -1932,11 +1927,6 @@ oauth@0.9.x:
   resolved "https://registry.yarnpkg.com/oauth/-/oauth-0.9.14.tgz#c5748883a40b53de30ade9cabf2100414b8a0971"
   integrity sha1-xXSIg6QLU94wrenKvyEAQUuKCXE=
 
-oauth@^0.9.15:
-  version "0.9.15"
-  resolved "https://registry.yarnpkg.com/oauth/-/oauth-0.9.15.tgz#bd1fefaf686c96b75475aed5196412ff60cfb9c1"
-  integrity sha1-vR/vr2hslrdUda7VGWQS/2DPucE=
-
 object-inspect@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-0.4.0.tgz#f5157c116c1455b243b06ee97703392c5ad89fec"
@@ -2040,6 +2030,13 @@ parseurl@~1.3.1:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
   integrity sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=
 
+"passport-apple@https://github.com/artsy/passport-apple":
+  version "1.1.2"
+  resolved "https://github.com/artsy/passport-apple#f41adb7822c8344b72bc36a7d68312f6592cb14f"
+  dependencies:
+    jsonwebtoken "^8.5.1"
+    passport-oauth2 "^1.5.0"
+
 passport-facebook@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/passport-facebook/-/passport-facebook-2.1.1.tgz#c39d0b52ae4d59163245a4e21a7b9b6321303311"
@@ -2056,7 +2053,18 @@ passport-oauth2@1.x.x:
     passport-strategy "1.x.x"
     uid2 "0.0.x"
 
-passport-strategy@1.x.x, passport-strategy@^1.0.0:
+passport-oauth2@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/passport-oauth2/-/passport-oauth2-1.5.0.tgz#64babbb54ac46a4dcab35e7f266ed5294e3c4108"
+  integrity sha512-kqBt6vR/5VlCK8iCx1/KpY42kQ+NEHZwsSyt4Y6STiNjU+wWICG1i8ucc1FapXDGO15C5O5VZz7+7vRzrDPXXQ==
+  dependencies:
+    base64url "3.x.x"
+    oauth "0.9.x"
+    passport-strategy "1.x.x"
+    uid2 "0.0.x"
+    utils-merge "1.x.x"
+
+passport-strategy@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/passport-strategy/-/passport-strategy-1.0.0.tgz#b5539aa8fc225a3d1ad179476ddf236b440f52e4"
   integrity sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ=
@@ -2888,7 +2896,7 @@ uid-safe@2.1.1:
     base64-url "1.2.2"
     random-bytes "~1.0.0"
 
-uid2@0.0.3, uid2@0.0.x:
+uid2@0.0.x:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/uid2/-/uid2-0.0.3.tgz#483126e11774df2f71b8b639dcd799c376162b82"
   integrity sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=
@@ -2953,6 +2961,11 @@ utils-merge@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
   integrity sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=
+
+utils-merge@1.x.x:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
+  integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
 vary@~1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This passes the JWT from sign in with apple back to our api for verification, see slack thread for details:
https://artsy.slack.com/archives/CN8S32FJR/p1599838945258600

- Points to an artsy fork of a passport-apple implementation with additional change of passing back entire id token: https://github.com/artsy/passport-apple/pull/1/files
- Passes back the idToken in callbacks to our apis
- Changes some minor parameter names for the new forked passport-apple version

Note:
I tested this by installing in locally running force and signing in, initially had troubles with xapp token not being passed in header I believe due to duplicate node_modules but if someone more familiar with this repo wants to pair on making sure this is working correctly would be appreciated.