### PR TITLE
chore: Add auto orb to publish package via CI

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,0 +1,3 @@
+{
+  "extends": "@artsy"
+}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,47 @@
 version: 2.1
 
 orbs:
-  yarn: artsy/yarn@0.1.8
+  yarn: artsy/yarn@5.1.3
+  auto: artsy/auto@1.3.2
+
+deploy: &deploy
+  context: npm-deploy
+  pre-steps:
+    - yarn/run-script:
+        script: pre-publish
+
+not_master: &not_master
+  filters:
+    branches:
+      ignore: master
+
+only_master: &only_master
+  filters:
+    branches:
+      only: master
 
 workflows:
   build_and_verify:
     jobs:
       - yarn/workflow-queue
+      - yarn/update-cache:
+          requires:
+            - yarn/workflow-queue
       - yarn/test:
           args: -c
           requires:
             - yarn/workflow-queue
+      # Pr builds
+      - auto/publish-canary:
+          <<: *not_master
+          <<: *deploy
+          requires:
+            - yarn/test
+            - yarn/update-cache
+      # Releases
+      - auto/publish:
+          <<: *only_master
+          <<: *deploy
+          requires:
+            - yarn/test
+            - yarn/update-cache

--- a/package.json
+++ b/package.json
@@ -24,12 +24,22 @@
     "node": ">=10.0.0",
     "yarn": "1.x.x"
   },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/artsy/artsy-passport.git"
+  },
   "main": "dist/index.js",
   "scripts": {
     "test": "mkdir -p dist/app && cp lib/app/sanitize_redirect.js dist/app && mocha test/app && mocha test/passport",
+    "clean": "rm -rf dist",
     "compile": "coffee -c -o dist lib; cp lib/app/sanitize_redirect.js dist/app",
     "compile-example": "browserify -t coffeeify example/client.coffee > example/public/client.js",
-    "example": "sleep 3 && open http://local.artsy.net:4000 & npm run compile && coffee example/index.coffee"
+    "example": "sleep 3 && open http://local.artsy.net:4000 & npm run compile && coffee example/index.coffee",
+    "pre-publish": "yarn clean && yarn compile"
   },
   "dependencies": {
     "@artsy/passport-local-with-otp": "^0.3.0",
@@ -48,6 +58,7 @@
     "underscore.string": "^3.2.2"
   },
   "devDependencies": {
+    "@artsy/auto-config": "1.0.2",
     "backbone": "*",
     "backbone-super-sync": "*",
     "body-parser": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@artsy/auto-config@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@artsy/auto-config/-/auto-config-1.0.2.tgz#b79f6fd0d0bda0c5e0764ced55e014cf58174d6f"
+  integrity sha512-mJyuKNDMYZcgc2oLIkvmpVIr1RexklV71JmU+to5qs3Y9pv5dsj4WHl8+wf9g74EQNOyhWH2SYMGBm1JoPYh/Q==
+
 "@artsy/passport-local-with-otp@^0.3.0":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@artsy/passport-local-with-otp/-/passport-local-with-otp-0.3.1.tgz#db3844f54599d40c5c2b1215d0edd82c15845440"


### PR DESCRIPTION
Updates CI config to add `auto` orb and publishing package via CI. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.5.1-canary.153.215.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @artsy/passport@1.5.1-canary.153.215.0
  # or 
  yarn add @artsy/passport@1.5.1-canary.153.215.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
