### PR TITLE
chore: Add roles to user options

### DIFF
--- a/lib/options.coffee
+++ b/lib/options.coffee
@@ -18,6 +18,7 @@ module.exports = {
   userKeys: [
     'id', 'type', 'name', 'email', 'phone', 'lab_features',
     'default_profile_id', 'has_partner_access', 'collector_level',
-    'recaptcha_token'
+    'recaptcha_token',
+    'roles'
   ]
 }


### PR DESCRIPTION
Add `roles` to user keys that are sent from passport to clients.

Related to https://github.com/artsy/force/pull/6584
https://artsyproduct.atlassian.net/browse/PLATFORM-2492